### PR TITLE
Remove dial-back prompt SMS on all non-reg public flows

### DIFF
--- a/go-app-personal.js
+++ b/go-app-personal.js
@@ -952,8 +952,21 @@ go.app = function() {
         };
 
         self.should_send_dialback = function(e) {
+            var dial_back_states = [
+                'states_language',
+                'states_register_info',
+                'states_suspect_pregnancy',
+                'states_id_type',
+                'states_sa_id',
+                'states_passport_origin',
+                'states_passport_no',
+                'states_birth_year',
+                'states_birth_month',
+                'states_birth_day'
+            ];
             return e.user_terminated
-                && !go.utils.is_true(self.contact.extra.redial_sms_sent);
+                && !go.utils.is_true(self.contact.extra.redial_sms_sent)
+                && _.contains(dial_back_states, e.im.state.name);
         };
 
         self.send_dialback = function() {

--- a/src/personal.js
+++ b/src/personal.js
@@ -59,8 +59,21 @@ go.app = function() {
         };
 
         self.should_send_dialback = function(e) {
+            var dial_back_states = [
+                'states_language',
+                'states_register_info',
+                'states_suspect_pregnancy',
+                'states_id_type',
+                'states_sa_id',
+                'states_passport_origin',
+                'states_passport_no',
+                'states_birth_year',
+                'states_birth_month',
+                'states_birth_day'
+            ];
             return e.user_terminated
-                && !go.utils.is_true(self.contact.extra.redial_sms_sent);
+                && !go.utils.is_true(self.contact.extra.redial_sms_sent)
+                && _.contains(dial_back_states, e.im.state.name);
         };
 
         self.send_dialback = function() {

--- a/test/personal.test.js
+++ b/test/personal.test.js
@@ -1128,7 +1128,7 @@ describe("app", function() {
                 });
 
                 describe("when they have not been sent a registration sms",function() {
-                    it("should send them an sms thanking them for their registration",function() {
+                    it("should send them an sms to dial back in",function() {
                         return tester
                             .setup(function(api) {
                                 api.contacts.add( {
@@ -1152,6 +1152,30 @@ describe("app", function() {
                                 assert.equal(sms.to_addr,'+273323');
                             }).run();
                     });
+                });
+            });
+
+            describe("when they are browsing faq",function() {
+                it("should not send them an sms",function() {
+                    return tester
+                        .setup(function(api) {
+                            api.contacts.add( {
+                                msisdn: '+273444',
+                                extra : {
+                                    redial_sms_sent: 'false'
+                                }
+                            });
+                        })
+                        .setup.user.addr('+273444')
+                        .setup.user.state('states_faq_topics')
+                        .input('1')
+                        .input.session_event('close')
+                        .check(function(api) {
+                            var smses = _.where(api.outbound.store, {
+                                endpoint: 'sms'
+                            });
+                            assert.equal(smses.length,0);
+                        }).run();
                 });
             });
         });


### PR DESCRIPTION
Currently all flows on the public line generate an SMS prompting the user to return and complete registration. This is not needed if they have completed reg and are in the FAQ browser flow.
