### PR TITLE
Make language restart a Promise

### DIFF
--- a/go-app-chw.js
+++ b/go-app-chw.js
@@ -886,6 +886,8 @@ go.utils = {
     set_language: function(user, contact) {
         if (contact.extra.language_choice !== null) {
             return user.set_lang(contact.extra.language_choice);
+        } else {
+            return Q();
         }
     }
 

--- a/go-app-clinic.js
+++ b/go-app-clinic.js
@@ -886,6 +886,8 @@ go.utils = {
     set_language: function(user, contact) {
         if (contact.extra.language_choice !== null) {
             return user.set_lang(contact.extra.language_choice);
+        } else {
+            return Q();
         }
     }
 

--- a/go-app-optout.js
+++ b/go-app-optout.js
@@ -886,6 +886,8 @@ go.utils = {
     set_language: function(user, contact) {
         if (contact.extra.language_choice !== null) {
             return user.set_lang(contact.extra.language_choice);
+        } else {
+            return Q();
         }
     }
 

--- a/go-app-personal.js
+++ b/go-app-personal.js
@@ -886,6 +886,8 @@ go.utils = {
     set_language: function(user, contact) {
         if (contact.extra.language_choice !== null) {
             return user.set_lang(contact.extra.language_choice);
+        } else {
+            return Q();
         }
     }
 
@@ -1011,13 +1013,17 @@ go.app = function() {
 
             } else if (self.contact.extra.is_registered_by === 'clinic') {
                 // registered on clinic line
-                go.utils.set_language(self.im.user, self.contact);
-                return self.states.create('states_registered_full');
+                return go.utils.set_language(self.im.user, self.contact)
+                    .then(function() {
+                        return self.states.create('states_registered_full');
+                    });
                     
             } else {
                 // registered on chw / public lines
-                go.utils.set_language(self.im.user, self.contact);
-                return self.states.create('states_registered_not_full');
+                return go.utils.set_language(self.im.user, self.contact)
+                    .then(function() {
+                        return self.states.create('states_registered_not_full');
+                    });
             }
         });
 

--- a/go-app-servicerating.js
+++ b/go-app-servicerating.js
@@ -886,6 +886,8 @@ go.utils = {
     set_language: function(user, contact) {
         if (contact.extra.language_choice !== null) {
             return user.set_lang(contact.extra.language_choice);
+        } else {
+            return Q();
         }
     }
 

--- a/go-app-smsinbound.js
+++ b/go-app-smsinbound.js
@@ -886,6 +886,8 @@ go.utils = {
     set_language: function(user, contact) {
         if (contact.extra.language_choice !== null) {
             return user.set_lang(contact.extra.language_choice);
+        } else {
+            return Q();
         }
     }
 

--- a/src/personal.js
+++ b/src/personal.js
@@ -118,13 +118,17 @@ go.app = function() {
 
             } else if (self.contact.extra.is_registered_by === 'clinic') {
                 // registered on clinic line
-                go.utils.set_language(self.im.user, self.contact);
-                return self.states.create('states_registered_full');
+                return go.utils.set_language(self.im.user, self.contact)
+                    .then(function() {
+                        return self.states.create('states_registered_full');
+                    });
                     
             } else {
                 // registered on chw / public lines
-                go.utils.set_language(self.im.user, self.contact);
-                return self.states.create('states_registered_not_full');
+                return go.utils.set_language(self.im.user, self.contact)
+                    .then(function() {
+                        return self.states.create('states_registered_not_full');
+                    });
             }
         });
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -883,6 +883,8 @@ go.utils = {
     set_language: function(user, contact) {
         if (contact.extra.language_choice !== null) {
             return user.set_lang(contact.extra.language_choice);
+        } else {
+            return Q();
         }
     }
 


### PR DESCRIPTION
Something like: 

```
set_language: function(user, contact) {
        if (contact.extra.language_choice !== null) {
            return user.set_lang(contact.extra.language_choice);
        } else {
          return Q();
        }
    }

self.states.add('question_1_friendliness', function(name) {
            go.utils.set_language(self.im.user, self.contact)
                .then(function(){
                    return new ChoiceState(name, {
                        question: $('Welcome. When you signed up, were staff at the facility friendly & helpful?'),

                        choices: [
                            new Choice('very-satisfied', $('Very Satisfied')),
                            new Choice('satisfied', $('Satisfied')),
                            new Choice('not-satisfied', $('Not Satisfied')),
                            new Choice('very-unsatisfied', $('Very unsatisfied'))
                        ],

                        next: 'question_2_waiting_times_feel'
                    });
                });
        });

```
