### PR TITLE
Add service rating status markers 

### DIFF
--- a/go-app-clinic.js
+++ b/go-app-clinic.js
@@ -1382,6 +1382,7 @@ go.app = function() {
                     self.contact.extra.is_registered = 'true';
                     self.contact.extra.is_registered_by = 'clinic';
                     self.contact.extra.metric_sessions_to_register = self.user.extra.ussd_sessions;
+                    self.contact.extra.service_rating_reminder = '0';
 
                     return self.im.groups.get(choice.value)
                         .then(function(group) {

--- a/go-app-servicerating.js
+++ b/go-app-servicerating.js
@@ -1012,8 +1012,12 @@ go.app = function() {
                             self.im.outbound.send_to_user({
                                     endpoint: 'sms',
                                     content: "Thank you for rating our service."
-                                })
-                        ]);
+                            }),
+                        ])
+                        .then(function() {
+                            self.contact.extra.last_service_rating = go.utils.get_timestamp();
+                            return self.im.contacts.save(self.contact);
+                        });
                     }
                 }
             });

--- a/src/clinic.js
+++ b/src/clinic.js
@@ -485,6 +485,7 @@ go.app = function() {
                     self.contact.extra.is_registered = 'true';
                     self.contact.extra.is_registered_by = 'clinic';
                     self.contact.extra.metric_sessions_to_register = self.user.extra.ussd_sessions;
+                    self.contact.extra.service_rating_reminder = '0';
 
                     return self.im.groups.get(choice.value)
                         .then(function(group) {

--- a/src/servicerating.js
+++ b/src/servicerating.js
@@ -115,8 +115,12 @@ go.app = function() {
                             self.im.outbound.send_to_user({
                                     endpoint: 'sms',
                                     content: "Thank you for rating our service."
-                                })
-                        ]);
+                            }),
+                        ])
+                        .then(function() {
+                            self.contact.extra.last_service_rating = go.utils.get_timestamp();
+                            return self.im.contacts.save(self.contact);
+                        });
                     }
                 }
             });

--- a/test/clinic.test.js
+++ b/test/clinic.test.js
@@ -1021,8 +1021,6 @@ describe("app", function() {
                             });
                             assert.equal(contact.extra.language_choice, 'en');
                             assert.equal(contact.extra.ussd_sessions, '0');
-                            assert.equal(contact.extra.is_registered, 'true');
-                            assert.equal(contact.extra.is_registered_by, 'clinic');
                             assert.equal(contact.extra.last_stage, 'states_end_success');
                             assert.equal(contact.extra.metric_sessions_to_register, '5');
                             assert.equal(contact.extra.no_registrations, undefined);

--- a/test/clinic.test.js
+++ b/test/clinic.test.js
@@ -970,6 +970,8 @@ describe("app", function() {
                             assert.equal(contact_mom.extra.is_registered_by, 'clinic');
                             assert.equal(contact_user.extra.is_registered, undefined);
                             assert.equal(contact_user.extra.is_registered_by, undefined);
+                            assert.equal(contact_mom.extra.service_rating_reminder, '0');
+                            assert.equal(contact_user.extra.service_rating_reminder, undefined);
                         })
                         .check(function(api) {
                             var metrics = api.metrics.stores.test_metric_store;
@@ -1029,6 +1031,7 @@ describe("app", function() {
                             assert.equal(contact.extra.subscription_rate, '3');
                             assert.equal(contact.extra.is_registered, 'true');
                             assert.equal(contact.extra.is_registered_by, 'clinic');
+                            assert.equal(contact.extra.service_rating_reminder, '0');
                         })
                         .check(function(api) {
                             var metrics = api.metrics.stores.test_metric_store;

--- a/test/servicerating.test.js
+++ b/test/servicerating.test.js
@@ -262,6 +262,12 @@ describe("app", function() {
                         );
                         assert.equal(sms.to_addr,'+27001');
                     })
+                    .check(function(api) {
+                            var contact = _.find(api.contacts.store, {
+                              msisdn: '+27001'
+                            });
+                            assert.equal(contact.extra.last_service_rating, '20130819144811');
+                        })
                     .check.reply.ends_session()
                     .run();
             });


### PR DESCRIPTION
Need to add markers that the service rating reminder service can consume. 
- [x] Clinic line: Add extra for: `service_rating_reminder` with value of `0` contact save.
- [x] Service rating line: Add extra for `last_service_rating` with value of current timestamp on completion
