### PR TITLE
Publish metrics in seconds for session length helper

### DIFF
--- a/go-app-chw.js
+++ b/go-app-chw.js
@@ -1162,8 +1162,8 @@ go.SessionLengthHelper = function () {
     };
 
     self.fire_metrics = function (name, result) {
-      return self
-        .im.metrics.fire.max([self.metrics_prefix, name].join('.'), result);
+      var full_name = [self.metrics_prefix, name].join('.');
+      return self.im.metrics.fire.max(full_name, result / 1000);
     };
 
     self.increment_and_fire = function (fn_or_str) {

--- a/go-app-clinic.js
+++ b/go-app-clinic.js
@@ -1162,8 +1162,8 @@ go.SessionLengthHelper = function () {
     };
 
     self.fire_metrics = function (name, result) {
-      return self
-        .im.metrics.fire.max([self.metrics_prefix, name].join('.'), result);
+      var full_name = [self.metrics_prefix, name].join('.');
+      return self.im.metrics.fire.max(full_name, result / 1000);
     };
 
     self.increment_and_fire = function (fn_or_str) {

--- a/go-app-optout.js
+++ b/go-app-optout.js
@@ -1162,8 +1162,8 @@ go.SessionLengthHelper = function () {
     };
 
     self.fire_metrics = function (name, result) {
-      return self
-        .im.metrics.fire.max([self.metrics_prefix, name].join('.'), result);
+      var full_name = [self.metrics_prefix, name].join('.');
+      return self.im.metrics.fire.max(full_name, result / 1000);
     };
 
     self.increment_and_fire = function (fn_or_str) {

--- a/go-app-personal.js
+++ b/go-app-personal.js
@@ -1162,8 +1162,8 @@ go.SessionLengthHelper = function () {
     };
 
     self.fire_metrics = function (name, result) {
-      return self
-        .im.metrics.fire.max([self.metrics_prefix, name].join('.'), result);
+      var full_name = [self.metrics_prefix, name].join('.');
+      return self.im.metrics.fire.max(full_name, result / 1000);
     };
 
     self.increment_and_fire = function (fn_or_str) {

--- a/go-app-servicerating.js
+++ b/go-app-servicerating.js
@@ -1162,8 +1162,8 @@ go.SessionLengthHelper = function () {
     };
 
     self.fire_metrics = function (name, result) {
-      return self
-        .im.metrics.fire.max([self.metrics_prefix, name].join('.'), result);
+      var full_name = [self.metrics_prefix, name].join('.');
+      return self.im.metrics.fire.max(full_name, result / 1000);
     };
 
     self.increment_and_fire = function (fn_or_str) {

--- a/go-app-smsinbound.js
+++ b/go-app-smsinbound.js
@@ -1162,8 +1162,8 @@ go.SessionLengthHelper = function () {
     };
 
     self.fire_metrics = function (name, result) {
-      return self
-        .im.metrics.fire.max([self.metrics_prefix, name].join('.'), result);
+      var full_name = [self.metrics_prefix, name].join('.');
+      return self.im.metrics.fire.max(full_name, result / 1000);
     };
 
     self.increment_and_fire = function (fn_or_str) {

--- a/src/session_length_helper.js
+++ b/src/session_length_helper.js
@@ -117,8 +117,8 @@ go.SessionLengthHelper = function () {
     };
 
     self.fire_metrics = function (name, result) {
-      return self
-        .im.metrics.fire.max([self.metrics_prefix, name].join('.'), result);
+      var full_name = [self.metrics_prefix, name].join('.');
+      return self.im.metrics.fire.max(full_name, result / 1000);
     };
 
     self.increment_and_fire = function (fn_or_str) {

--- a/test/chw.test.js
+++ b/test/chw.test.js
@@ -165,7 +165,7 @@ describe("app", function() {
                         assert.equal(
                           m_store['session_length_helper.unspecified'].agg, 'max');
                         assert.equal(
-                          m_store['session_length_helper.unspecified'].values[0], 60000);
+                          m_store['session_length_helper.unspecified'].values[0], 60);
                     }).run();
             });
 
@@ -196,7 +196,7 @@ describe("app", function() {
                         assert.equal(
                           m_store['session_length_helper.unknown'].agg, 'max');
                         assert.equal(
-                          m_store['session_length_helper.unknown'].values[0], 60000);
+                          m_store['session_length_helper.unknown'].values[0], 60);
                     }).run();
             });
         });

--- a/test/chw.test.js
+++ b/test/chw.test.js
@@ -132,7 +132,7 @@ describe("app", function() {
                         assert.equal(
                           m_store['session_length_helper.foodacom'].agg, 'max');
                         assert.equal(
-                          m_store['session_length_helper.foodacom'].values[0], 60000);
+                          m_store['session_length_helper.foodacom'].values[0], 60);
                     }).run();
             });
         });

--- a/test/clinic.test.js
+++ b/test/clinic.test.js
@@ -190,7 +190,7 @@ describe("app", function() {
                         assert.equal(
                           m_store['session_length_helper.foodacom'].agg, 'max');
                         assert.equal(
-                          m_store['session_length_helper.foodacom'].values[0], 60000);
+                          m_store['session_length_helper.foodacom'].values[0], 60);
                     }).run();
             });
         });

--- a/test/optout.test.js
+++ b/test/optout.test.js
@@ -137,7 +137,7 @@ describe("app", function() {
                         assert.equal(
                           m_store['session_length_helper.foodacom'].agg, 'max');
                         assert.equal(
-                          m_store['session_length_helper.foodacom'].values[0], 60000);
+                          m_store['session_length_helper.foodacom'].values[0], 60);
                     }).run();
             });
         });

--- a/test/personal.test.js
+++ b/test/personal.test.js
@@ -148,7 +148,7 @@ describe("app", function() {
                         assert.equal(
                           m_store['session_length_helper.foodacom'].agg, 'max');
                         assert.equal(
-                          m_store['session_length_helper.foodacom'].values[0], 60000);
+                          m_store['session_length_helper.foodacom'].values[0], 60);
                     }).run();
             });
         });

--- a/test/session_length_helper.test.js
+++ b/test/session_length_helper.test.js
@@ -130,7 +130,7 @@ describe('SessionLengthHelper', function() {
           assert.equal(
             m_store['session_length_helper.vodacom'].agg, 'max');
           assert.equal(
-            m_store['session_length_helper.vodacom'].values[0], 1000);
+            m_store['session_length_helper.vodacom'].values[0], 1);
         })
         .run();
     });

--- a/test/smsinbound.test.js
+++ b/test/smsinbound.test.js
@@ -134,7 +134,7 @@ describe("app", function() {
                         assert.equal(
                           m_store['session_length_helper.foodacom'].agg, 'max');
                         assert.equal(
-                          m_store['session_length_helper.foodacom'].values[0], 60000);
+                          m_store['session_length_helper.foodacom'].values[0], 60);
                     }).run();
             });
         });


### PR DESCRIPTION
Milliseconds will probably confused people, we should divide by `1000` when publishing the duration.
