### PR TITLE
Change how re-joining visitors are treated on public

### DIFF
--- a/go-app-chw.js
+++ b/go-app-chw.js
@@ -847,7 +847,24 @@ go.utils = {
                 } else {
                     return Q();
                 }
+            });
+    },
 
+    subscription_count_active: function(contact, im) {
+        var params = {
+            to_addr: contact.msisdn
+        };
+        return go.utils
+            .control_api_call("get", params, null, 'subscription/', im)
+            .then(function(json_result) {
+                var subs = JSON.parse(json_result.data);
+                var active = 0;
+                for (i=0;i<subs.objects.length;i++) {
+                    if (subs.objects[i].active === true) {
+                        active += 1;
+                    }
+                }
+                return active;
             });
     },
 

--- a/go-app-chw.js
+++ b/go-app-chw.js
@@ -861,7 +861,7 @@ go.utils = {
                 var active = 0;
                 for (i=0;i<subs.objects.length;i++) {
                     if (subs.objects[i].active === true) {
-                        active += 1;
+                        active++;
                     }
                 }
                 return active;

--- a/go-app-clinic.js
+++ b/go-app-clinic.js
@@ -847,7 +847,24 @@ go.utils = {
                 } else {
                     return Q();
                 }
+            });
+    },
 
+    subscription_count_active: function(contact, im) {
+        var params = {
+            to_addr: contact.msisdn
+        };
+        return go.utils
+            .control_api_call("get", params, null, 'subscription/', im)
+            .then(function(json_result) {
+                var subs = JSON.parse(json_result.data);
+                var active = 0;
+                for (i=0;i<subs.objects.length;i++) {
+                    if (subs.objects[i].active === true) {
+                        active += 1;
+                    }
+                }
+                return active;
             });
     },
 

--- a/go-app-clinic.js
+++ b/go-app-clinic.js
@@ -861,7 +861,7 @@ go.utils = {
                 var active = 0;
                 for (i=0;i<subs.objects.length;i++) {
                     if (subs.objects[i].active === true) {
-                        active += 1;
+                        active++;
                     }
                 }
                 return active;

--- a/go-app-optout.js
+++ b/go-app-optout.js
@@ -847,7 +847,24 @@ go.utils = {
                 } else {
                     return Q();
                 }
+            });
+    },
 
+    subscription_count_active: function(contact, im) {
+        var params = {
+            to_addr: contact.msisdn
+        };
+        return go.utils
+            .control_api_call("get", params, null, 'subscription/', im)
+            .then(function(json_result) {
+                var subs = JSON.parse(json_result.data);
+                var active = 0;
+                for (i=0;i<subs.objects.length;i++) {
+                    if (subs.objects[i].active === true) {
+                        active += 1;
+                    }
+                }
+                return active;
             });
     },
 

--- a/go-app-optout.js
+++ b/go-app-optout.js
@@ -861,7 +861,7 @@ go.utils = {
                 var active = 0;
                 for (i=0;i<subs.objects.length;i++) {
                     if (subs.objects[i].active === true) {
-                        active += 1;
+                        active++;
                     }
                 }
                 return active;

--- a/go-app-personal.js
+++ b/go-app-personal.js
@@ -1405,7 +1405,7 @@ go.app = function() {
                             .then(function(count) {
                                 if (count === 0) {
                                     // if no active subscriptions, register user
-                                    if (!self.im.config.faq_enabled && !self.im.config.detailed_data_collection) {
+                                    if (!self.im.config.faq_enabled) {
                                         return self.states.create('states_suspect_pregnancy', opts);
                                     } else {
                                         return self.states.create('states_register_info', opts);
@@ -1575,7 +1575,7 @@ go.app = function() {
                                     return self.im.contacts.save(self.contact);
                                 })
                                 .then(function() {
-                                    if (!self.im.config.faq_enabled && !self.im.config.detailed_data_collection){
+                                    if (!self.im.config.faq_enabled){
                                         return 'states_suspect_pregnancy';
                                     } else {
                                         return 'states_register_info';

--- a/go-app-personal.js
+++ b/go-app-personal.js
@@ -861,7 +861,7 @@ go.utils = {
                 var active = 0;
                 for (i=0;i<subs.objects.length;i++) {
                     if (subs.objects[i].active === true) {
-                        active += 1;
+                        active++;
                     }
                 }
                 return active;

--- a/go-app-personal.js
+++ b/go-app-personal.js
@@ -847,7 +847,24 @@ go.utils = {
                 } else {
                     return Q();
                 }
+            });
+    },
 
+    subscription_count_active: function(contact, im) {
+        var params = {
+            to_addr: contact.msisdn
+        };
+        return go.utils
+            .control_api_call("get", params, null, 'subscription/', im)
+            .then(function(json_result) {
+                var subs = JSON.parse(json_result.data);
+                var active = 0;
+                for (i=0;i<subs.objects.length;i++) {
+                    if (subs.objects[i].active === true) {
+                        active += 1;
+                    }
+                }
+                return active;
             });
     },
 
@@ -1380,9 +1397,23 @@ go.app = function() {
 
             } else if (self.contact.extra.is_registered_by === 'clinic') {
                 // registered on clinic line
-                return go.utils.set_language(self.im.user, self.contact)
+                return go.utils
+                    .set_language(self.im.user, self.contact)
                     .then(function() {
-                        return self.states.create('states_registered_full', opts);
+                        return go.utils
+                            .subscription_count_active(self.contact, self.im)
+                            .then(function(count) {
+                                if (count === 0) {
+                                    // if no active subscriptions, register user
+                                    if (!self.im.config.faq_enabled && !self.im.config.detailed_data_collection) {
+                                        return self.states.create('states_suspect_pregnancy', opts);
+                                    } else {
+                                        return self.states.create('states_register_info', opts);
+                                    }
+                                } else {
+                                    return self.states.create('states_registered_full', opts);
+                                }
+                            });
                     });
 
             } else {
@@ -1547,9 +1578,9 @@ go.app = function() {
                                     if (!self.im.config.faq_enabled && !self.im.config.detailed_data_collection){
                                         return 'states_suspect_pregnancy';
                                     } else {
-                                        return 'states_register_info'; 
+                                        return 'states_register_info';
                                     }
-                                    
+
                                 });
                         });
                 },

--- a/go-app-servicerating.js
+++ b/go-app-servicerating.js
@@ -847,7 +847,24 @@ go.utils = {
                 } else {
                     return Q();
                 }
+            });
+    },
 
+    subscription_count_active: function(contact, im) {
+        var params = {
+            to_addr: contact.msisdn
+        };
+        return go.utils
+            .control_api_call("get", params, null, 'subscription/', im)
+            .then(function(json_result) {
+                var subs = JSON.parse(json_result.data);
+                var active = 0;
+                for (i=0;i<subs.objects.length;i++) {
+                    if (subs.objects[i].active === true) {
+                        active += 1;
+                    }
+                }
+                return active;
             });
     },
 

--- a/go-app-servicerating.js
+++ b/go-app-servicerating.js
@@ -861,7 +861,7 @@ go.utils = {
                 var active = 0;
                 for (i=0;i<subs.objects.length;i++) {
                     if (subs.objects[i].active === true) {
-                        active += 1;
+                        active++;
                     }
                 }
                 return active;

--- a/go-app-smsinbound.js
+++ b/go-app-smsinbound.js
@@ -847,7 +847,24 @@ go.utils = {
                 } else {
                     return Q();
                 }
+            });
+    },
 
+    subscription_count_active: function(contact, im) {
+        var params = {
+            to_addr: contact.msisdn
+        };
+        return go.utils
+            .control_api_call("get", params, null, 'subscription/', im)
+            .then(function(json_result) {
+                var subs = JSON.parse(json_result.data);
+                var active = 0;
+                for (i=0;i<subs.objects.length;i++) {
+                    if (subs.objects[i].active === true) {
+                        active += 1;
+                    }
+                }
+                return active;
             });
     },
 

--- a/go-app-smsinbound.js
+++ b/go-app-smsinbound.js
@@ -861,7 +861,7 @@ go.utils = {
                 var active = 0;
                 for (i=0;i<subs.objects.length;i++) {
                     if (subs.objects[i].active === true) {
-                        active += 1;
+                        active++;
                     }
                 }
                 return active;

--- a/src/personal.js
+++ b/src/personal.js
@@ -175,7 +175,7 @@ go.app = function() {
                             .then(function(count) {
                                 if (count === 0) {
                                     // if no active subscriptions, register user
-                                    if (!self.im.config.faq_enabled && !self.im.config.detailed_data_collection) {
+                                    if (!self.im.config.faq_enabled) {
                                         return self.states.create('states_suspect_pregnancy', opts);
                                     } else {
                                         return self.states.create('states_register_info', opts);
@@ -345,7 +345,7 @@ go.app = function() {
                                     return self.im.contacts.save(self.contact);
                                 })
                                 .then(function() {
-                                    if (!self.im.config.faq_enabled && !self.im.config.detailed_data_collection){
+                                    if (!self.im.config.faq_enabled){
                                         return 'states_suspect_pregnancy';
                                     } else {
                                         return 'states_register_info';

--- a/src/personal.js
+++ b/src/personal.js
@@ -167,9 +167,23 @@ go.app = function() {
 
             } else if (self.contact.extra.is_registered_by === 'clinic') {
                 // registered on clinic line
-                return go.utils.set_language(self.im.user, self.contact)
+                return go.utils
+                    .set_language(self.im.user, self.contact)
                     .then(function() {
-                        return self.states.create('states_registered_full', opts);
+                        return go.utils
+                            .subscription_count_active(self.contact, self.im)
+                            .then(function(count) {
+                                if (count === 0) {
+                                    // if no active subscriptions, register user
+                                    if (!self.im.config.faq_enabled && !self.im.config.detailed_data_collection) {
+                                        return self.states.create('states_suspect_pregnancy', opts);
+                                    } else {
+                                        return self.states.create('states_register_info', opts);
+                                    }
+                                } else {
+                                    return self.states.create('states_registered_full', opts);
+                                }
+                            });
                     });
 
             } else {
@@ -334,9 +348,9 @@ go.app = function() {
                                     if (!self.im.config.faq_enabled && !self.im.config.detailed_data_collection){
                                         return 'states_suspect_pregnancy';
                                     } else {
-                                        return 'states_register_info'; 
+                                        return 'states_register_info';
                                     }
-                                    
+
                                 });
                         });
                 },

--- a/src/utils.js
+++ b/src/utils.js
@@ -858,7 +858,7 @@ go.utils = {
                 var active = 0;
                 for (i=0;i<subs.objects.length;i++) {
                     if (subs.objects[i].active === true) {
-                        active += 1;
+                        active++;
                     }
                 }
                 return active;

--- a/src/utils.js
+++ b/src/utils.js
@@ -844,7 +844,24 @@ go.utils = {
                 } else {
                     return Q();
                 }
+            });
+    },
 
+    subscription_count_active: function(contact, im) {
+        var params = {
+            to_addr: contact.msisdn
+        };
+        return go.utils
+            .control_api_call("get", params, null, 'subscription/', im)
+            .then(function(json_result) {
+                var subs = JSON.parse(json_result.data);
+                var active = 0;
+                for (i=0;i<subs.objects.length;i++) {
+                    if (subs.objects[i].active === true) {
+                        active += 1;
+                    }
+                }
+                return active;
             });
     },
 

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -1037,6 +1037,125 @@ module.exports = function() {
             }
         }
     },
+    // PERSONAL - COUNT ACTIVE SUBSCRIPTIONS
+    {
+        'request': {
+            'method': 'GET',
+            'params': {
+                'to_addr': '+27821234444'
+            },
+            'headers': {
+                'Authorization': ['Basic ' + new Buffer('test:test').toString('base64')],
+                'Content-Type': ['application/json']
+            },
+            'url': 'http://ndoh-control/api/v1/subscription/',
+        },
+        'response': {
+            "code": 200,
+            "meta": {
+                "limit": 20,
+                "next": null,
+                "offset": 0,
+                "previous": null,
+                "total_count": 2
+            },
+            "data": {
+                "objects": [
+                    {
+                        "active": false,
+                        "completed": false,
+                        "contact_key": "e5b0888cdb4347158ea5cd2f2147d28f",
+                        "created_at": "2014-08-05T11:22:34.838969",
+                        "id": 1,
+                        "lang": "en",
+                        "message_set": "/api/v1/message_set/3/",
+                        "next_sequence_number": 1,
+                        "process_status": 0,
+                        "resource_uri": "/api/v1/subscription/1/",
+                        "schedule": "/api/v1/periodic_task/1/",
+                        "to_addr": "+27821234444",
+                        "updated_at": "2014-08-05T11:22:34.838996",
+                        "user_account": "1aa0dea2f82945a48cc258c61d756f16"
+                    },
+                    {
+                        "active": true,
+                        "completed": false,
+                        "contact_key": "e5b0888cdb4347158ea5cd2f2147d28f",
+                        "created_at": "2014-08-05T11:31:50.908974",
+                        "id": 2,
+                        "lang": "af",
+                        "message_set": "/api/v1/message_set/3/",
+                        "next_sequence_number": 1,
+                        "process_status": 0,
+                        "resource_uri": "/api/v1/subscription/2/",
+                        "schedule": "/api/v1/periodic_task/1/",
+                        "to_addr": "+27821234444",
+                        "updated_at": "2014-08-05T11:31:50.909025",
+                        "user_account": "1aa0dea2f82945a48cc258c61d756f16"
+                    }
+                ]
+            }
+        }
+    },
+    {
+        'request': {
+            'method': 'GET',
+            'params': {
+                'to_addr': '+27821235555'
+            },
+            'headers': {
+                'Authorization': ['Basic ' + new Buffer('test:test').toString('base64')],
+                'Content-Type': ['application/json']
+            },
+            'url': 'http://ndoh-control/api/v1/subscription/',
+        },
+        'response': {
+            "code": 200,
+            "meta": {
+                "limit": 20,
+                "next": null,
+                "offset": 0,
+                "previous": null,
+                "total_count": 2
+            },
+            "data": {
+                "objects": [
+                    {
+                        "active": false,
+                        "completed": false,
+                        "contact_key": "e5b0888cdb4347158ea5cd2f2147d28f",
+                        "created_at": "2014-08-05T11:22:34.838969",
+                        "id": 1,
+                        "lang": "en",
+                        "message_set": "/api/v1/message_set/3/",
+                        "next_sequence_number": 1,
+                        "process_status": 0,
+                        "resource_uri": "/api/v1/subscription/1/",
+                        "schedule": "/api/v1/periodic_task/1/",
+                        "to_addr": "+27821235555",
+                        "updated_at": "2014-08-05T11:22:34.838996",
+                        "user_account": "1aa0dea2f82945a48cc258c61d756f16"
+                    },
+                    {
+                        "active": false,
+                        "completed": false,
+                        "contact_key": "e5b0888cdb4347158ea5cd2f2147d28f",
+                        "created_at": "2014-08-05T11:31:50.908974",
+                        "id": 2,
+                        "lang": "af",
+                        "message_set": "/api/v1/message_set/3/",
+                        "next_sequence_number": 1,
+                        "process_status": 0,
+                        "resource_uri": "/api/v1/subscription/2/",
+                        "schedule": "/api/v1/periodic_task/1/",
+                        "to_addr": "+27821235555",
+                        "updated_at": "2014-08-05T11:31:50.909025",
+                        "user_account": "1aa0dea2f82945a48cc258c61d756f16"
+                    }
+                ]
+            }
+        }
+    },
     // PERSONAL - DATA LIMITED
     {
         'request': {

--- a/test/personal.test.js
+++ b/test/personal.test.js
@@ -519,32 +519,63 @@ describe("app", function() {
             });
 
             describe("when the user has registered on clinic", function() {
-                it("should prompt for info / compliment / complaint", function() {
-                    return tester
-                        .setup(function(api) {
-                            api.contacts.add({
-                                msisdn: '+27001',
-                                extra : {
-                                    language_choice: 'xh',
-                                    is_registered: 'true',
-                                    is_registered_by: 'clinic'
-                                },
-                            });
-                        })
-                        .setup.user.addr('27001')
-                        .start()
-                        .check.interaction({
-                            state: 'states_registered_full',
-                            reply: [
-                                'Welcome to the Department of Health\'s ' +
-                                'MomConnect. Please choose an option:',
-                                '1. Baby and pregnancy info',
-                                '2. Send us a compliment',
-                                '3. Send us a complaint'
-                            ].join('\n')
-                        })
-                        .check.user.properties({lang: 'xh'})
-                        .run();
+                describe("when the user has active subscriptions", function() {
+                    it("should prompt for info / compliment / complaint", function() {
+                        return tester
+                            .setup(function(api) {
+                                api.contacts.add({
+                                    msisdn: '+27001',
+                                    extra : {
+                                        language_choice: 'xh',
+                                        is_registered: 'true',
+                                        is_registered_by: 'clinic'
+                                    },
+                                });
+                            })
+                            .setup.user.addr('27001')
+                            .start()
+                            .check.interaction({
+                                state: 'states_registered_full',
+                                reply: [
+                                    'Welcome to the Department of Health\'s ' +
+                                    'MomConnect. Please choose an option:',
+                                    '1. Baby and pregnancy info',
+                                    '2. Send us a compliment',
+                                    '3. Send us a complaint'
+                                ].join('\n')
+                            })
+                            .check.user.properties({lang: 'xh'})
+                            .run();
+                    });
+                });
+
+                describe("when the user has no active subscriptions", function() {
+                    it("should ask if they want to register or get info", function() {
+                        return tester
+                            .setup(function(api) {
+                                api.contacts.add({
+                                    msisdn: '+27821235555',
+                                    extra : {
+                                        language_choice: 'xh',
+                                        is_registered: 'true',
+                                        is_registered_by: 'clinic'
+                                    },
+                                });
+                            })
+                            .setup.user.addr('27821235555')
+                            .start()
+                            .check.interaction({
+                                state: 'states_register_info',
+                                reply: [
+                                    'Welcome to the Department of Health\'s ' +
+                                    'MomConnect. Please select:',
+                                    '1. Register for messages',
+                                    '2. Baby and Pregnancy info (English only)'
+                                ].join('\n')
+                            })
+                            .check.user.properties({lang: 'xh'})
+                            .run();
+                    });
                 });
             });
 
@@ -2164,6 +2195,67 @@ describe("app", function() {
                                 '2. Main menu'
                             ].join('\n')
                         })
+                        .run();
+                });
+            });
+        });
+
+        describe("when the user has registered on clinic", function() {
+            describe("when the user has active subscriptions", function() {
+                it("should prompt for info / compliment / complaint", function() {
+                    return tester
+                        .setup(function(api) {
+                            api.contacts.add({
+                                msisdn: '+27001',
+                                extra : {
+                                    language_choice: 'xh',
+                                    is_registered: 'true',
+                                    is_registered_by: 'clinic'
+                                },
+                            });
+                        })
+                        .setup.user.addr('27001')
+                        .start()
+                        .check.interaction({
+                            state: 'states_registered_full',
+                            reply: [
+                                'Welcome to the Department of Health\'s ' +
+                                'MomConnect. Please choose an option:',
+                                '1. Send us a compliment',
+                                '2. Send us a complaint'
+                            ].join('\n')
+                        })
+                        .check.user.properties({lang: 'xh'})
+                        .run();
+                });
+            });
+
+            describe("when the user has no active subscriptions", function() {
+                it("should ask if they want to register or get info", function() {
+                    return tester
+                        .setup(function(api) {
+                            api.contacts.add({
+                                msisdn: '+27821235555',
+                                extra : {
+                                    language_choice: 'xh',
+                                    is_registered: 'true',
+                                    is_registered_by: 'clinic'
+                                },
+                            });
+                        })
+                        .setup.user.addr('27821235555')
+                        .start()
+                        .check.interaction({
+                            state: 'states_suspect_pregnancy',
+                            reply: [
+                                'MomConnect sends free support SMSs to ' +
+                                'pregnant mothers. Are you or do you suspect ' +
+                                'that you are pregnant?',
+                                '1. Yes',
+                                '2. No'
+                            ].join('\n')
+                        })
+                        .check.user.properties({lang: 'xh'})
                         .run();
                 });
             });


### PR DESCRIPTION
If a user has been registered at a Clinic at some point, but now have 0 Active Subscriptions, when they log on to the Public line, they should be treated as if not registered, but skip the Language screen.
