### PR TITLE
Additional Subscription metrics

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -167,26 +167,26 @@ module.exports = function (grunt) {
             options: {
                 reporter: 'spec'
             },
-            test_clinic: {
-                src: ['<%= paths.test.clinic %>']
-            },
-            test_chw: {
-                src: ['<%= paths.test.chw %>']
-            },
-            test_personal: {
-                src: ['<%= paths.test.personal %>']
-            },
+            // test_clinic: {
+            //     src: ['<%= paths.test.clinic %>']
+            // },
+            // test_chw: {
+            //     src: ['<%= paths.test.chw %>']
+            // },
+            // test_personal: {
+            //     src: ['<%= paths.test.personal %>']
+            // },
             test_optout: {
                 src: ['<%= paths.test.optout %>']
             },
             test_smsinbound: {
                 src: ['<%= paths.test.smsinbound %>']
-            },
-            test_servicerating: {
-                src: ['<%= paths.test.servicerating %>']
-            },
-            test_session_length_helper: {
-                src: ['<%= paths.test.session_length_helper %>']
+            // },
+            // test_servicerating: {
+            //     src: ['<%= paths.test.servicerating %>']
+            // },
+            // test_session_length_helper: {
+            //     src: ['<%= paths.test.session_length_helper %>']
             }
         }
     });

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -178,9 +178,9 @@ module.exports = function (grunt) {
             // },
             test_optout: {
                 src: ['<%= paths.test.optout %>']
-            },
-            test_smsinbound: {
-                src: ['<%= paths.test.smsinbound %>']
+            // },
+            // test_smsinbound: {
+            //     src: ['<%= paths.test.smsinbound %>']
             // },
             // test_servicerating: {
             //     src: ['<%= paths.test.servicerating %>']

--- a/go-app-chw.js
+++ b/go-app-chw.js
@@ -1018,7 +1018,7 @@ go.utils = {
             && im.user.state.name !== 'states_start';
     },
 
-    opt_out: function(im, contact, env) {
+    get_reg_source: function(contact) {
         // determine registration source with default 'unknown'
         var reg_source;
         var registration_options = ['clinic', 'chw', 'personal'];
@@ -1027,14 +1027,17 @@ go.utils = {
         } else {
             reg_source = contact.extra.is_registered_by;
         }
+        return reg_source;
+    },
 
+    opt_out: function(im, contact, env) {
         return Q.all([
             im.api_request('optout.optout', {
                 address_type: "msisdn",
                 address_value: contact.msisdn,
                 message_id: im.msg.message_id
             }),
-            im.metrics.fire.inc([env, 'sum', 'optout', reg_source].join('.'), 1)
+            im.metrics.fire.inc([env, 'sum', 'optout', go.utils.get_reg_source(contact)].join('.'), 1)
         ]);
     },
 

--- a/go-app-chw.js
+++ b/go-app-chw.js
@@ -1018,12 +1018,24 @@ go.utils = {
             && im.user.state.name !== 'states_start';
     },
 
-    opt_out: function(im, contact) {
-        return im.api_request('optout.optout', {
-            address_type: "msisdn",
-            address_value: contact.msisdn,
-            message_id: im.msg.message_id
-        });
+    opt_out: function(im, contact, env) {
+        // determine registration source with default 'unknown'
+        var reg_source;
+        var registration_options = ['clinic', 'chw', 'personal'];
+        if (!_.contains(registration_options, contact.extra.is_registered_by)) {
+            reg_source = 'unknown';
+        } else {
+            reg_source = contact.extra.is_registered_by;
+        }
+
+        return Q.all([
+            im.api_request('optout.optout', {
+                address_type: "msisdn",
+                address_value: contact.msisdn,
+                message_id: im.msg.message_id
+            }),
+            im.metrics.fire.inc([env, 'sum', 'optout', reg_source].join('.'), 1)
+        ]);
     },
 
     opted_out: function(im, contact) {

--- a/go-app-chw.js
+++ b/go-app-chw.js
@@ -1030,14 +1030,15 @@ go.utils = {
         return reg_source;
     },
 
-    opt_out: function(im, contact, env) {
+    opt_out: function(im, contact, env, reason) {
         return Q.all([
             im.api_request('optout.optout', {
                 address_type: "msisdn",
                 address_value: contact.msisdn,
                 message_id: im.msg.message_id
             }),
-            im.metrics.fire.inc([env, 'sum', 'optout', go.utils.get_reg_source(contact)].join('.'), {amount:1})
+            im.metrics.fire.inc([env, 'sum', 'optout', go.utils.get_reg_source(contact)].join('.'), {amount:1}),
+            im.metrics.fire.inc([env, 'sum', 'optout_cause', reason].join('.'), {amount:1})
         ]);
     },
 

--- a/go-app-chw.js
+++ b/go-app-chw.js
@@ -681,7 +681,8 @@ go.utils = {
             return Q.all([
                 im.metrics.fire.last([metric_prefix, 'percent_incomplete_registrations'].join('.'), percentage_incomplete),
                 im.metrics.fire.last([metric_prefix, 'percent_complete_registrations'].join('.'), percentage_complete),
-                im.metrics.fire.inc([env, 'sum', 'registrations'].join('.'), 1)
+                im.metrics.fire.inc([env, 'sum', 'registrations'].join('.'), 1),
+                go.utils.incr_kv(im, [env, 'sum', 'registrations'].join('.'))
             ]);
         });
     },

--- a/go-app-chw.js
+++ b/go-app-chw.js
@@ -1031,6 +1031,78 @@ go.utils = {
     },
 
     opt_out: function(im, contact, env, reason) {
+        // sms-inbound STOP
+            // api optout.optout
+            // unsubscribe_all
+            // metric | optout_on    = clinic/personal/chw +1
+            // metric | optout_cause = 'unknown' +1
+            // kv     | optout_total = +1
+            // kv     | optout_loss  = 0
+
+        // optout
+            // suffers baby loss
+                // signs up for loss messages
+                    // no previous optout
+                        // unsubscribe_all
+                        // subscribe to loss messages
+                        // metric | optout_on    = clinic/personal/chw +1
+                        // metric | optout_cause = miscarriage/babyloss/stillbirth +1
+                        //                       = unknown 0
+                        // kv     | optout_total = +1
+                        // kv     | optout_loss  = +1
+                        // kv     | signup = +1
+
+                    // previous optout
+                        // api opt_in.opt_in
+                        // subscribe to loss messages
+                        // metric | optout_on    = 0
+                        // metric | optout_cause = miscarriage/babyloss/stillbirth +1
+                        //                       = unknown -1
+                        // kv     | optout_total = 0
+                        // kv     | optout_loss  = +1
+                        // kv     | signup = +1
+
+
+                // doesn't sign up for loss messages
+                    // no previous optout
+                        // api optout.optout
+                        // unsubscribe_all
+                        // metric | optout_on    = clinic/personal/chw +1
+                        // metric | optout_cause = miscarriage/babyloss/stillbirth +1
+                        // kv     | optout_total = +1
+                        // kv     | optout_loss  = +1
+                        // kv     | signup = 0
+
+                    // previous optout
+                        // -
+                        // metric | optout_on    = 0
+                        // metric | optout_cause = miscarriage/babyloss/stillbirth +1
+                        //                       = unknown -1
+                        // kv     | optout_total = 0
+                        // kv     | optout_loss  = +1
+                        // kv     | signup = 0
+
+            // chooses not_useful / other
+                // no previous optout
+                    // api optout.optout
+                    // unsubscribe_all
+                    // metric | optout_on    = clinic/personal/chw +1
+                    // metric | optout_cause = not_useful/other +1
+                    // kv     | optout_total = +1
+                    // kv     | optout_loss  = 0
+
+                // previous optout
+                    // -
+                    // metric | optout_on    = 0
+                    // metric | optout_cause = not_useful/other +1
+                    //                       = unknown -1
+                    // kv     | optout_total = 0
+                    // kv     | optout_loss  = 0
+
+
+
+
+
         return Q.all([
             im.api_request('optout.optout', {
                 address_type: "msisdn",
@@ -1038,7 +1110,8 @@ go.utils = {
                 message_id: im.msg.message_id
             }),
             im.metrics.fire.inc([env, 'sum', 'optout_on', go.utils.get_reg_source(contact)].join('.'), {amount:1}),
-            im.metrics.fire.inc([env, 'sum', 'optout_cause', reason].join('.'), {amount:1})
+            im.metrics.fire.inc([env, 'sum', 'optout_cause', reason].join('.'), {amount:1}),
+            go.utils.incr_kv(im, [env, 'sum', 'optout', 'all'].join('.'))
         ]);
     },
 

--- a/go-app-chw.js
+++ b/go-app-chw.js
@@ -681,7 +681,7 @@ go.utils = {
             return Q.all([
                 im.metrics.fire.last([metric_prefix, 'percent_incomplete_registrations'].join('.'), percentage_incomplete),
                 im.metrics.fire.last([metric_prefix, 'percent_complete_registrations'].join('.'), percentage_complete),
-                im.metrics.fire.inc([env, 'sum', 'registrations'].join('.'), 1),
+                im.metrics.fire.inc([env, 'sum', 'registrations'].join('.'), {amount:1}),
                 go.utils.incr_kv(im, [env, 'sum', 'registrations'].join('.'))
             ]);
         });
@@ -1037,7 +1037,7 @@ go.utils = {
                 address_value: contact.msisdn,
                 message_id: im.msg.message_id
             }),
-            im.metrics.fire.inc([env, 'sum', 'optout', go.utils.get_reg_source(contact)].join('.'), 1)
+            im.metrics.fire.inc([env, 'sum', 'optout', go.utils.get_reg_source(contact)].join('.'), {amount:1})
         ]);
     },
 

--- a/go-app-chw.js
+++ b/go-app-chw.js
@@ -1037,7 +1037,7 @@ go.utils = {
                 address_value: contact.msisdn,
                 message_id: im.msg.message_id
             }),
-            im.metrics.fire.inc([env, 'sum', 'optout', go.utils.get_reg_source(contact)].join('.'), {amount:1}),
+            im.metrics.fire.inc([env, 'sum', 'optout_on', go.utils.get_reg_source(contact)].join('.'), {amount:1}),
             im.metrics.fire.inc([env, 'sum', 'optout_cause', reason].join('.'), {amount:1})
         ]);
     },

--- a/go-app-chw.js
+++ b/go-app-chw.js
@@ -670,7 +670,7 @@ go.utils = {
             });
     },
 
-    adjust_percentage_registrations: function(im, metric_prefix) {
+    adjust_percentage_registrations: function(im, metric_prefix, env) {
         return Q.all([
             go.utils.get_kv(im, [metric_prefix, 'no_incomplete_registrations'].join('.'), 0),
             go.utils.get_kv(im, [metric_prefix, 'no_complete_registrations'].join('.'), 0)
@@ -680,7 +680,8 @@ go.utils = {
             var percentage_complete = (no_complete / total_attempted) * 100;
             return Q.all([
                 im.metrics.fire.last([metric_prefix, 'percent_incomplete_registrations'].join('.'), percentage_incomplete),
-                im.metrics.fire.last([metric_prefix, 'percent_complete_registrations'].join('.'), percentage_complete)
+                im.metrics.fire.last([metric_prefix, 'percent_complete_registrations'].join('.'), percentage_complete),
+                im.metrics.fire.inc([env, 'sum', 'registrations'].join('.'), 1)
             ]);
         });
     },
@@ -1510,7 +1511,7 @@ go.app = function() {
                         return go.utils
                             .incr_kv(self.im, [self.store_name, 'no_incomplete_registrations'].join('.'))
                             .then(function() {
-                                return go.utils.adjust_percentage_registrations(self.im, self.metric_prefix);
+                                return go.utils.adjust_percentage_registrations(self.im, self.metric_prefix, self.env);
                             });
                     }
                 }
@@ -1732,7 +1733,7 @@ go.app = function() {
                                         go.utils.decr_kv(self.im, [self.store_name, 'no_incomplete_registrations'].join('.'))
                                     ])
                                         .then(function() {
-                                            return go.utils.adjust_percentage_registrations(self.im, self.metric_prefix);
+                                            return go.utils.adjust_percentage_registrations(self.im, self.metric_prefix, self.env);
                                         });
                                 })
                                 .then(function() {

--- a/go-app-clinic.js
+++ b/go-app-clinic.js
@@ -1018,7 +1018,7 @@ go.utils = {
             && im.user.state.name !== 'states_start';
     },
 
-    opt_out: function(im, contact, env) {
+    get_reg_source: function(contact) {
         // determine registration source with default 'unknown'
         var reg_source;
         var registration_options = ['clinic', 'chw', 'personal'];
@@ -1027,14 +1027,17 @@ go.utils = {
         } else {
             reg_source = contact.extra.is_registered_by;
         }
+        return reg_source;
+    },
 
+    opt_out: function(im, contact, env) {
         return Q.all([
             im.api_request('optout.optout', {
                 address_type: "msisdn",
                 address_value: contact.msisdn,
                 message_id: im.msg.message_id
             }),
-            im.metrics.fire.inc([env, 'sum', 'optout', reg_source].join('.'), 1)
+            im.metrics.fire.inc([env, 'sum', 'optout', go.utils.get_reg_source(contact)].join('.'), 1)
         ]);
     },
 

--- a/go-app-clinic.js
+++ b/go-app-clinic.js
@@ -1018,12 +1018,24 @@ go.utils = {
             && im.user.state.name !== 'states_start';
     },
 
-    opt_out: function(im, contact) {
-        return im.api_request('optout.optout', {
-            address_type: "msisdn",
-            address_value: contact.msisdn,
-            message_id: im.msg.message_id
-        });
+    opt_out: function(im, contact, env) {
+        // determine registration source with default 'unknown'
+        var reg_source;
+        var registration_options = ['clinic', 'chw', 'personal'];
+        if (!_.contains(registration_options, contact.extra.is_registered_by)) {
+            reg_source = 'unknown';
+        } else {
+            reg_source = contact.extra.is_registered_by;
+        }
+
+        return Q.all([
+            im.api_request('optout.optout', {
+                address_type: "msisdn",
+                address_value: contact.msisdn,
+                message_id: im.msg.message_id
+            }),
+            im.metrics.fire.inc([env, 'sum', 'optout', reg_source].join('.'), 1)
+        ]);
     },
 
     opted_out: function(im, contact) {

--- a/go-app-clinic.js
+++ b/go-app-clinic.js
@@ -670,7 +670,7 @@ go.utils = {
             });
     },
 
-    adjust_percentage_registrations: function(im, metric_prefix) {
+    adjust_percentage_registrations: function(im, metric_prefix, env) {
         return Q.all([
             go.utils.get_kv(im, [metric_prefix, 'no_incomplete_registrations'].join('.'), 0),
             go.utils.get_kv(im, [metric_prefix, 'no_complete_registrations'].join('.'), 0)
@@ -680,7 +680,8 @@ go.utils = {
             var percentage_complete = (no_complete / total_attempted) * 100;
             return Q.all([
                 im.metrics.fire.last([metric_prefix, 'percent_incomplete_registrations'].join('.'), percentage_incomplete),
-                im.metrics.fire.last([metric_prefix, 'percent_complete_registrations'].join('.'), percentage_complete)
+                im.metrics.fire.last([metric_prefix, 'percent_complete_registrations'].join('.'), percentage_complete),
+                im.metrics.fire.inc([env, 'sum', 'registrations'].join('.'), 1)
             ]);
         });
     },
@@ -1488,7 +1489,7 @@ go.app = function() {
                         return go.utils
                             .incr_kv(self.im, [self.store_name, 'no_incomplete_registrations'].join('.'))
                             .then(function() {
-                                return go.utils.adjust_percentage_registrations(self.im, self.metric_prefix);
+                                return go.utils.adjust_percentage_registrations(self.im, self.metric_prefix, self.env);
                             });
                     }
                 }
@@ -1833,7 +1834,7 @@ go.app = function() {
                                         go.utils.decr_kv(self.im, [self.store_name, 'no_incomplete_registrations'].join('.'))
                                     ])
                                         .then(function() {
-                                            return go.utils.adjust_percentage_registrations(self.im, self.metric_prefix);
+                                            return go.utils.adjust_percentage_registrations(self.im, self.metric_prefix, self.env);
                                         });
                                 })
                                 .then(function() {

--- a/go-app-clinic.js
+++ b/go-app-clinic.js
@@ -1030,14 +1030,15 @@ go.utils = {
         return reg_source;
     },
 
-    opt_out: function(im, contact, env) {
+    opt_out: function(im, contact, env, reason) {
         return Q.all([
             im.api_request('optout.optout', {
                 address_type: "msisdn",
                 address_value: contact.msisdn,
                 message_id: im.msg.message_id
             }),
-            im.metrics.fire.inc([env, 'sum', 'optout', go.utils.get_reg_source(contact)].join('.'), {amount:1})
+            im.metrics.fire.inc([env, 'sum', 'optout', go.utils.get_reg_source(contact)].join('.'), {amount:1}),
+            im.metrics.fire.inc([env, 'sum', 'optout_cause', reason].join('.'), {amount:1})
         ]);
     },
 

--- a/go-app-clinic.js
+++ b/go-app-clinic.js
@@ -681,7 +681,8 @@ go.utils = {
             return Q.all([
                 im.metrics.fire.last([metric_prefix, 'percent_incomplete_registrations'].join('.'), percentage_incomplete),
                 im.metrics.fire.last([metric_prefix, 'percent_complete_registrations'].join('.'), percentage_complete),
-                im.metrics.fire.inc([env, 'sum', 'registrations'].join('.'), 1)
+                im.metrics.fire.inc([env, 'sum', 'registrations'].join('.'), 1),
+                go.utils.incr_kv(im, [env, 'sum', 'registrations'].join('.'))
             ]);
         });
     },

--- a/go-app-clinic.js
+++ b/go-app-clinic.js
@@ -1031,6 +1031,78 @@ go.utils = {
     },
 
     opt_out: function(im, contact, env, reason) {
+        // sms-inbound STOP
+            // api optout.optout
+            // unsubscribe_all
+            // metric | optout_on    = clinic/personal/chw +1
+            // metric | optout_cause = 'unknown' +1
+            // kv     | optout_total = +1
+            // kv     | optout_loss  = 0
+
+        // optout
+            // suffers baby loss
+                // signs up for loss messages
+                    // no previous optout
+                        // unsubscribe_all
+                        // subscribe to loss messages
+                        // metric | optout_on    = clinic/personal/chw +1
+                        // metric | optout_cause = miscarriage/babyloss/stillbirth +1
+                        //                       = unknown 0
+                        // kv     | optout_total = +1
+                        // kv     | optout_loss  = +1
+                        // kv     | signup = +1
+
+                    // previous optout
+                        // api opt_in.opt_in
+                        // subscribe to loss messages
+                        // metric | optout_on    = 0
+                        // metric | optout_cause = miscarriage/babyloss/stillbirth +1
+                        //                       = unknown -1
+                        // kv     | optout_total = 0
+                        // kv     | optout_loss  = +1
+                        // kv     | signup = +1
+
+
+                // doesn't sign up for loss messages
+                    // no previous optout
+                        // api optout.optout
+                        // unsubscribe_all
+                        // metric | optout_on    = clinic/personal/chw +1
+                        // metric | optout_cause = miscarriage/babyloss/stillbirth +1
+                        // kv     | optout_total = +1
+                        // kv     | optout_loss  = +1
+                        // kv     | signup = 0
+
+                    // previous optout
+                        // -
+                        // metric | optout_on    = 0
+                        // metric | optout_cause = miscarriage/babyloss/stillbirth +1
+                        //                       = unknown -1
+                        // kv     | optout_total = 0
+                        // kv     | optout_loss  = +1
+                        // kv     | signup = 0
+
+            // chooses not_useful / other
+                // no previous optout
+                    // api optout.optout
+                    // unsubscribe_all
+                    // metric | optout_on    = clinic/personal/chw +1
+                    // metric | optout_cause = not_useful/other +1
+                    // kv     | optout_total = +1
+                    // kv     | optout_loss  = 0
+
+                // previous optout
+                    // -
+                    // metric | optout_on    = 0
+                    // metric | optout_cause = not_useful/other +1
+                    //                       = unknown -1
+                    // kv     | optout_total = 0
+                    // kv     | optout_loss  = 0
+
+
+
+
+
         return Q.all([
             im.api_request('optout.optout', {
                 address_type: "msisdn",
@@ -1038,7 +1110,8 @@ go.utils = {
                 message_id: im.msg.message_id
             }),
             im.metrics.fire.inc([env, 'sum', 'optout_on', go.utils.get_reg_source(contact)].join('.'), {amount:1}),
-            im.metrics.fire.inc([env, 'sum', 'optout_cause', reason].join('.'), {amount:1})
+            im.metrics.fire.inc([env, 'sum', 'optout_cause', reason].join('.'), {amount:1}),
+            go.utils.incr_kv(im, [env, 'sum', 'optout', 'all'].join('.'))
         ]);
     },
 

--- a/go-app-clinic.js
+++ b/go-app-clinic.js
@@ -681,7 +681,7 @@ go.utils = {
             return Q.all([
                 im.metrics.fire.last([metric_prefix, 'percent_incomplete_registrations'].join('.'), percentage_incomplete),
                 im.metrics.fire.last([metric_prefix, 'percent_complete_registrations'].join('.'), percentage_complete),
-                im.metrics.fire.inc([env, 'sum', 'registrations'].join('.'), 1),
+                im.metrics.fire.inc([env, 'sum', 'registrations'].join('.'), {amount:1}),
                 go.utils.incr_kv(im, [env, 'sum', 'registrations'].join('.'))
             ]);
         });
@@ -1037,7 +1037,7 @@ go.utils = {
                 address_value: contact.msisdn,
                 message_id: im.msg.message_id
             }),
-            im.metrics.fire.inc([env, 'sum', 'optout', go.utils.get_reg_source(contact)].join('.'), 1)
+            im.metrics.fire.inc([env, 'sum', 'optout', go.utils.get_reg_source(contact)].join('.'), {amount:1})
         ]);
     },
 

--- a/go-app-clinic.js
+++ b/go-app-clinic.js
@@ -1037,7 +1037,7 @@ go.utils = {
                 address_value: contact.msisdn,
                 message_id: im.msg.message_id
             }),
-            im.metrics.fire.inc([env, 'sum', 'optout', go.utils.get_reg_source(contact)].join('.'), {amount:1}),
+            im.metrics.fire.inc([env, 'sum', 'optout_on', go.utils.get_reg_source(contact)].join('.'), {amount:1}),
             im.metrics.fire.inc([env, 'sum', 'optout_cause', reason].join('.'), {amount:1})
         ]);
     },

--- a/go-app-optout.js
+++ b/go-app-optout.js
@@ -1031,6 +1031,78 @@ go.utils = {
     },
 
     opt_out: function(im, contact, env, reason) {
+        // sms-inbound STOP
+            // api optout.optout
+            // unsubscribe_all
+            // metric | optout_on    = clinic/personal/chw +1
+            // metric | optout_cause = 'unknown' +1
+            // kv     | optout_total = +1
+            // kv     | optout_loss  = 0
+
+        // optout
+            // suffers baby loss
+                // signs up for loss messages
+                    // no previous optout
+                        // unsubscribe_all
+                        // subscribe to loss messages
+                        // metric | optout_on    = clinic/personal/chw +1
+                        // metric | optout_cause = miscarriage/babyloss/stillbirth +1
+                        //                       = unknown 0
+                        // kv     | optout_total = +1
+                        // kv     | optout_loss  = +1
+                        // kv     | signup = +1
+
+                    // previous optout
+                        // api opt_in.opt_in
+                        // subscribe to loss messages
+                        // metric | optout_on    = 0
+                        // metric | optout_cause = miscarriage/babyloss/stillbirth +1
+                        //                       = unknown -1
+                        // kv     | optout_total = 0
+                        // kv     | optout_loss  = +1
+                        // kv     | signup = +1
+
+
+                // doesn't sign up for loss messages
+                    // no previous optout
+                        // api optout.optout
+                        // unsubscribe_all
+                        // metric | optout_on    = clinic/personal/chw +1
+                        // metric | optout_cause = miscarriage/babyloss/stillbirth +1
+                        // kv     | optout_total = +1
+                        // kv     | optout_loss  = +1
+                        // kv     | signup = 0
+
+                    // previous optout
+                        // -
+                        // metric | optout_on    = 0
+                        // metric | optout_cause = miscarriage/babyloss/stillbirth +1
+                        //                       = unknown -1
+                        // kv     | optout_total = 0
+                        // kv     | optout_loss  = +1
+                        // kv     | signup = 0
+
+            // chooses not_useful / other
+                // no previous optout
+                    // api optout.optout
+                    // unsubscribe_all
+                    // metric | optout_on    = clinic/personal/chw +1
+                    // metric | optout_cause = not_useful/other +1
+                    // kv     | optout_total = +1
+                    // kv     | optout_loss  = 0
+
+                // previous optout
+                    // -
+                    // metric | optout_on    = 0
+                    // metric | optout_cause = not_useful/other +1
+                    //                       = unknown -1
+                    // kv     | optout_total = 0
+                    // kv     | optout_loss  = 0
+
+
+
+
+
         return Q.all([
             im.api_request('optout.optout', {
                 address_type: "msisdn",
@@ -1038,7 +1110,8 @@ go.utils = {
                 message_id: im.msg.message_id
             }),
             im.metrics.fire.inc([env, 'sum', 'optout_on', go.utils.get_reg_source(contact)].join('.'), {amount:1}),
-            im.metrics.fire.inc([env, 'sum', 'optout_cause', reason].join('.'), {amount:1})
+            im.metrics.fire.inc([env, 'sum', 'optout_cause', reason].join('.'), {amount:1}),
+            go.utils.incr_kv(im, [env, 'sum', 'optout', 'all'].join('.'))
         ]);
     },
 
@@ -1267,6 +1340,7 @@ go.app = function() {
                                 question = $('Please let us know why you do not want MomConnect messages');
                             } else {
                                 self.contact.extra.prior_opt_out = 'true';
+                                self.contact.extra.prior_opt_out_reason = self.contact.extra.opt_out_reason || 'unknown';
                                 question = $('Please tell us why you previously opted out of messages');
                             }
 
@@ -1290,7 +1364,9 @@ go.app = function() {
                                             if (_.contains(['not_useful', 'other'], choice.value)){
                                                 if (self.contact.extra.prior_opt_out === 'true') {
                                                     return self.im.metrics.fire
-                                                        .inc([self.env, 'sum', 'optout_cause', 'unknown'].join('.'), {amount:-1}) // decrease unknown opt_outs
+                                                        // decrease prior opt_outs
+                                                        .inc([self.env, 'sum', 'optout_cause',
+                                                            self.contact.extra.prior_opt_out_reason].join('.'), {amount:-1})
                                                         .then(function() {
                                                             return 'states_end_no_optout';
                                                         });
@@ -1344,7 +1420,7 @@ go.app = function() {
                                 ]).then(function() {
                                     if (self.contact.extra.prior_opt_out === 'true') {
                                         return self.im.metrics.fire
-                                            .inc([self.env, 'sum', 'optout_cause', 'unknown'].join('.'), {amount:-1}) // decrease unknown opt_outs
+                                            .inc([self.env, 'sum', 'optout_cause', self.contact.extra.prior_opt_out_reason].join('.'), {amount:-1}) // decrease unknown opt_outs
                                             .then(function() {
                                                 return 'states_end_yes';
                                             });
@@ -1362,7 +1438,11 @@ go.app = function() {
                             .jembi_send_json(self.contact, self.contact, 'subscription', self.im, self.metric_prefix)
                             .then(function() {
                                 if (self.contact.extra.prior_opt_out === 'true') {
-                                    return 'states_end_no';
+                                    return self.im.metrics.fire
+                                        .inc([self.env, 'sum', 'optout_cause', self.contact.extra.prior_opt_out_reason].join('.'), {amount:-1}) // decrease unknown opt_outs
+                                        .then(function() {
+                                            return 'states_end_no_optout';
+                                        });
                                 } else {
                                     return 'states_end_no_optout';
                                 }

--- a/go-app-optout.js
+++ b/go-app-optout.js
@@ -681,7 +681,7 @@ go.utils = {
             return Q.all([
                 im.metrics.fire.last([metric_prefix, 'percent_incomplete_registrations'].join('.'), percentage_incomplete),
                 im.metrics.fire.last([metric_prefix, 'percent_complete_registrations'].join('.'), percentage_complete),
-                im.metrics.fire.inc([env, 'sum', 'registrations'].join('.'), 1),
+                im.metrics.fire.inc([env, 'sum', 'registrations'].join('.'), {amount:1}),
                 go.utils.incr_kv(im, [env, 'sum', 'registrations'].join('.'))
             ]);
         });
@@ -1037,7 +1037,7 @@ go.utils = {
                 address_value: contact.msisdn,
                 message_id: im.msg.message_id
             }),
-            im.metrics.fire.inc([env, 'sum', 'optout', go.utils.get_reg_source(contact)].join('.'), 1)
+            im.metrics.fire.inc([env, 'sum', 'optout', go.utils.get_reg_source(contact)].join('.'), {amount:1})
         ]);
     },
 
@@ -1340,7 +1340,7 @@ go.app = function() {
                                         return 'states_end_yes';
                                     } else {
                                         return self.im.metrics.fire
-                                            .inc([self.env, 'sum', 'optout', go.utils.get_reg_source(self.contact)].join('.'), 1)
+                                            .inc([self.env, 'sum', 'optout', go.utils.get_reg_source(self.contact)].join('.'), {amount:1})
                                             .then(function() {
                                                 return 'states_end_yes';
                                             });

--- a/go-app-optout.js
+++ b/go-app-optout.js
@@ -1037,7 +1037,7 @@ go.utils = {
                 address_value: contact.msisdn,
                 message_id: im.msg.message_id
             }),
-            im.metrics.fire.inc([env, 'sum', 'optout', go.utils.get_reg_source(contact)].join('.'), {amount:1}),
+            im.metrics.fire.inc([env, 'sum', 'optout_on', go.utils.get_reg_source(contact)].join('.'), {amount:1}),
             im.metrics.fire.inc([env, 'sum', 'optout_cause', reason].join('.'), {amount:1})
         ]);
     },
@@ -1350,7 +1350,7 @@ go.app = function() {
                                             });
                                     } else {
                                         return self.im.metrics.fire
-                                            .inc([self.env, 'sum', 'optout', go.utils.get_reg_source(self.contact)].join('.'), {amount:1})
+                                            .inc([self.env, 'sum', 'optout_on', go.utils.get_reg_source(self.contact)].join('.'), {amount:1})
                                             .then(function() {
                                                 return 'states_end_yes';
                                             });

--- a/go-app-optout.js
+++ b/go-app-optout.js
@@ -681,7 +681,8 @@ go.utils = {
             return Q.all([
                 im.metrics.fire.last([metric_prefix, 'percent_incomplete_registrations'].join('.'), percentage_incomplete),
                 im.metrics.fire.last([metric_prefix, 'percent_complete_registrations'].join('.'), percentage_complete),
-                im.metrics.fire.inc([env, 'sum', 'registrations'].join('.'), 1)
+                im.metrics.fire.inc([env, 'sum', 'registrations'].join('.'), 1),
+                go.utils.incr_kv(im, [env, 'sum', 'registrations'].join('.'))
             ]);
         });
     },

--- a/go-app-optout.js
+++ b/go-app-optout.js
@@ -670,7 +670,7 @@ go.utils = {
             });
     },
 
-    adjust_percentage_registrations: function(im, metric_prefix) {
+    adjust_percentage_registrations: function(im, metric_prefix, env) {
         return Q.all([
             go.utils.get_kv(im, [metric_prefix, 'no_incomplete_registrations'].join('.'), 0),
             go.utils.get_kv(im, [metric_prefix, 'no_complete_registrations'].join('.'), 0)
@@ -680,7 +680,8 @@ go.utils = {
             var percentage_complete = (no_complete / total_attempted) * 100;
             return Q.all([
                 im.metrics.fire.last([metric_prefix, 'percent_incomplete_registrations'].join('.'), percentage_incomplete),
-                im.metrics.fire.last([metric_prefix, 'percent_complete_registrations'].join('.'), percentage_complete)
+                im.metrics.fire.last([metric_prefix, 'percent_complete_registrations'].join('.'), percentage_complete),
+                im.metrics.fire.inc([env, 'sum', 'registrations'].join('.'), 1)
             ]);
         });
     },

--- a/go-app-personal.js
+++ b/go-app-personal.js
@@ -1018,7 +1018,7 @@ go.utils = {
             && im.user.state.name !== 'states_start';
     },
 
-    opt_out: function(im, contact, env) {
+    get_reg_source: function(contact) {
         // determine registration source with default 'unknown'
         var reg_source;
         var registration_options = ['clinic', 'chw', 'personal'];
@@ -1027,14 +1027,17 @@ go.utils = {
         } else {
             reg_source = contact.extra.is_registered_by;
         }
+        return reg_source;
+    },
 
+    opt_out: function(im, contact, env) {
         return Q.all([
             im.api_request('optout.optout', {
                 address_type: "msisdn",
                 address_value: contact.msisdn,
                 message_id: im.msg.message_id
             }),
-            im.metrics.fire.inc([env, 'sum', 'optout', reg_source].join('.'), 1)
+            im.metrics.fire.inc([env, 'sum', 'optout', go.utils.get_reg_source(contact)].join('.'), 1)
         ]);
     },
 

--- a/go-app-personal.js
+++ b/go-app-personal.js
@@ -1018,12 +1018,24 @@ go.utils = {
             && im.user.state.name !== 'states_start';
     },
 
-    opt_out: function(im, contact) {
-        return im.api_request('optout.optout', {
-            address_type: "msisdn",
-            address_value: contact.msisdn,
-            message_id: im.msg.message_id
-        });
+    opt_out: function(im, contact, env) {
+        // determine registration source with default 'unknown'
+        var reg_source;
+        var registration_options = ['clinic', 'chw', 'personal'];
+        if (!_.contains(registration_options, contact.extra.is_registered_by)) {
+            reg_source = 'unknown';
+        } else {
+            reg_source = contact.extra.is_registered_by;
+        }
+
+        return Q.all([
+            im.api_request('optout.optout', {
+                address_type: "msisdn",
+                address_value: contact.msisdn,
+                message_id: im.msg.message_id
+            }),
+            im.metrics.fire.inc([env, 'sum', 'optout', reg_source].join('.'), 1)
+        ]);
     },
 
     opted_out: function(im, contact) {

--- a/go-app-personal.js
+++ b/go-app-personal.js
@@ -1030,14 +1030,15 @@ go.utils = {
         return reg_source;
     },
 
-    opt_out: function(im, contact, env) {
+    opt_out: function(im, contact, env, reason) {
         return Q.all([
             im.api_request('optout.optout', {
                 address_type: "msisdn",
                 address_value: contact.msisdn,
                 message_id: im.msg.message_id
             }),
-            im.metrics.fire.inc([env, 'sum', 'optout', go.utils.get_reg_source(contact)].join('.'), {amount:1})
+            im.metrics.fire.inc([env, 'sum', 'optout', go.utils.get_reg_source(contact)].join('.'), {amount:1}),
+            im.metrics.fire.inc([env, 'sum', 'optout_cause', reason].join('.'), {amount:1})
         ]);
     },
 

--- a/go-app-personal.js
+++ b/go-app-personal.js
@@ -681,7 +681,8 @@ go.utils = {
             return Q.all([
                 im.metrics.fire.last([metric_prefix, 'percent_incomplete_registrations'].join('.'), percentage_incomplete),
                 im.metrics.fire.last([metric_prefix, 'percent_complete_registrations'].join('.'), percentage_complete),
-                im.metrics.fire.inc([env, 'sum', 'registrations'].join('.'), 1)
+                im.metrics.fire.inc([env, 'sum', 'registrations'].join('.'), 1),
+                go.utils.incr_kv(im, [env, 'sum', 'registrations'].join('.'))
             ]);
         });
     },

--- a/go-app-personal.js
+++ b/go-app-personal.js
@@ -1031,6 +1031,78 @@ go.utils = {
     },
 
     opt_out: function(im, contact, env, reason) {
+        // sms-inbound STOP
+            // api optout.optout
+            // unsubscribe_all
+            // metric | optout_on    = clinic/personal/chw +1
+            // metric | optout_cause = 'unknown' +1
+            // kv     | optout_total = +1
+            // kv     | optout_loss  = 0
+
+        // optout
+            // suffers baby loss
+                // signs up for loss messages
+                    // no previous optout
+                        // unsubscribe_all
+                        // subscribe to loss messages
+                        // metric | optout_on    = clinic/personal/chw +1
+                        // metric | optout_cause = miscarriage/babyloss/stillbirth +1
+                        //                       = unknown 0
+                        // kv     | optout_total = +1
+                        // kv     | optout_loss  = +1
+                        // kv     | signup = +1
+
+                    // previous optout
+                        // api opt_in.opt_in
+                        // subscribe to loss messages
+                        // metric | optout_on    = 0
+                        // metric | optout_cause = miscarriage/babyloss/stillbirth +1
+                        //                       = unknown -1
+                        // kv     | optout_total = 0
+                        // kv     | optout_loss  = +1
+                        // kv     | signup = +1
+
+
+                // doesn't sign up for loss messages
+                    // no previous optout
+                        // api optout.optout
+                        // unsubscribe_all
+                        // metric | optout_on    = clinic/personal/chw +1
+                        // metric | optout_cause = miscarriage/babyloss/stillbirth +1
+                        // kv     | optout_total = +1
+                        // kv     | optout_loss  = +1
+                        // kv     | signup = 0
+
+                    // previous optout
+                        // -
+                        // metric | optout_on    = 0
+                        // metric | optout_cause = miscarriage/babyloss/stillbirth +1
+                        //                       = unknown -1
+                        // kv     | optout_total = 0
+                        // kv     | optout_loss  = +1
+                        // kv     | signup = 0
+
+            // chooses not_useful / other
+                // no previous optout
+                    // api optout.optout
+                    // unsubscribe_all
+                    // metric | optout_on    = clinic/personal/chw +1
+                    // metric | optout_cause = not_useful/other +1
+                    // kv     | optout_total = +1
+                    // kv     | optout_loss  = 0
+
+                // previous optout
+                    // -
+                    // metric | optout_on    = 0
+                    // metric | optout_cause = not_useful/other +1
+                    //                       = unknown -1
+                    // kv     | optout_total = 0
+                    // kv     | optout_loss  = 0
+
+
+
+
+
         return Q.all([
             im.api_request('optout.optout', {
                 address_type: "msisdn",
@@ -1038,7 +1110,8 @@ go.utils = {
                 message_id: im.msg.message_id
             }),
             im.metrics.fire.inc([env, 'sum', 'optout_on', go.utils.get_reg_source(contact)].join('.'), {amount:1}),
-            im.metrics.fire.inc([env, 'sum', 'optout_cause', reason].join('.'), {amount:1})
+            im.metrics.fire.inc([env, 'sum', 'optout_cause', reason].join('.'), {amount:1}),
+            go.utils.incr_kv(im, [env, 'sum', 'optout', 'all'].join('.'))
         ]);
     },
 

--- a/go-app-personal.js
+++ b/go-app-personal.js
@@ -681,7 +681,7 @@ go.utils = {
             return Q.all([
                 im.metrics.fire.last([metric_prefix, 'percent_incomplete_registrations'].join('.'), percentage_incomplete),
                 im.metrics.fire.last([metric_prefix, 'percent_complete_registrations'].join('.'), percentage_complete),
-                im.metrics.fire.inc([env, 'sum', 'registrations'].join('.'), 1),
+                im.metrics.fire.inc([env, 'sum', 'registrations'].join('.'), {amount:1}),
                 go.utils.incr_kv(im, [env, 'sum', 'registrations'].join('.'))
             ]);
         });
@@ -1037,7 +1037,7 @@ go.utils = {
                 address_value: contact.msisdn,
                 message_id: im.msg.message_id
             }),
-            im.metrics.fire.inc([env, 'sum', 'optout', go.utils.get_reg_source(contact)].join('.'), 1)
+            im.metrics.fire.inc([env, 'sum', 'optout', go.utils.get_reg_source(contact)].join('.'), {amount:1})
         ]);
     },
 

--- a/go-app-personal.js
+++ b/go-app-personal.js
@@ -1037,7 +1037,7 @@ go.utils = {
                 address_value: contact.msisdn,
                 message_id: im.msg.message_id
             }),
-            im.metrics.fire.inc([env, 'sum', 'optout', go.utils.get_reg_source(contact)].join('.'), {amount:1}),
+            im.metrics.fire.inc([env, 'sum', 'optout_on', go.utils.get_reg_source(contact)].join('.'), {amount:1}),
             im.metrics.fire.inc([env, 'sum', 'optout_cause', reason].join('.'), {amount:1})
         ]);
     },

--- a/go-app-servicerating.js
+++ b/go-app-servicerating.js
@@ -1018,7 +1018,7 @@ go.utils = {
             && im.user.state.name !== 'states_start';
     },
 
-    opt_out: function(im, contact, env) {
+    get_reg_source: function(contact) {
         // determine registration source with default 'unknown'
         var reg_source;
         var registration_options = ['clinic', 'chw', 'personal'];
@@ -1027,14 +1027,17 @@ go.utils = {
         } else {
             reg_source = contact.extra.is_registered_by;
         }
+        return reg_source;
+    },
 
+    opt_out: function(im, contact, env) {
         return Q.all([
             im.api_request('optout.optout', {
                 address_type: "msisdn",
                 address_value: contact.msisdn,
                 message_id: im.msg.message_id
             }),
-            im.metrics.fire.inc([env, 'sum', 'optout', reg_source].join('.'), 1)
+            im.metrics.fire.inc([env, 'sum', 'optout', go.utils.get_reg_source(contact)].join('.'), 1)
         ]);
     },
 

--- a/go-app-servicerating.js
+++ b/go-app-servicerating.js
@@ -1018,12 +1018,24 @@ go.utils = {
             && im.user.state.name !== 'states_start';
     },
 
-    opt_out: function(im, contact) {
-        return im.api_request('optout.optout', {
-            address_type: "msisdn",
-            address_value: contact.msisdn,
-            message_id: im.msg.message_id
-        });
+    opt_out: function(im, contact, env) {
+        // determine registration source with default 'unknown'
+        var reg_source;
+        var registration_options = ['clinic', 'chw', 'personal'];
+        if (!_.contains(registration_options, contact.extra.is_registered_by)) {
+            reg_source = 'unknown';
+        } else {
+            reg_source = contact.extra.is_registered_by;
+        }
+
+        return Q.all([
+            im.api_request('optout.optout', {
+                address_type: "msisdn",
+                address_value: contact.msisdn,
+                message_id: im.msg.message_id
+            }),
+            im.metrics.fire.inc([env, 'sum', 'optout', reg_source].join('.'), 1)
+        ]);
     },
 
     opted_out: function(im, contact) {

--- a/go-app-servicerating.js
+++ b/go-app-servicerating.js
@@ -1030,14 +1030,15 @@ go.utils = {
         return reg_source;
     },
 
-    opt_out: function(im, contact, env) {
+    opt_out: function(im, contact, env, reason) {
         return Q.all([
             im.api_request('optout.optout', {
                 address_type: "msisdn",
                 address_value: contact.msisdn,
                 message_id: im.msg.message_id
             }),
-            im.metrics.fire.inc([env, 'sum', 'optout', go.utils.get_reg_source(contact)].join('.'), {amount:1})
+            im.metrics.fire.inc([env, 'sum', 'optout', go.utils.get_reg_source(contact)].join('.'), {amount:1}),
+            im.metrics.fire.inc([env, 'sum', 'optout_cause', reason].join('.'), {amount:1})
         ]);
     },
 

--- a/go-app-servicerating.js
+++ b/go-app-servicerating.js
@@ -681,7 +681,8 @@ go.utils = {
             return Q.all([
                 im.metrics.fire.last([metric_prefix, 'percent_incomplete_registrations'].join('.'), percentage_incomplete),
                 im.metrics.fire.last([metric_prefix, 'percent_complete_registrations'].join('.'), percentage_complete),
-                im.metrics.fire.inc([env, 'sum', 'registrations'].join('.'), 1)
+                im.metrics.fire.inc([env, 'sum', 'registrations'].join('.'), 1),
+                go.utils.incr_kv(im, [env, 'sum', 'registrations'].join('.'))
             ]);
         });
     },

--- a/go-app-servicerating.js
+++ b/go-app-servicerating.js
@@ -1031,6 +1031,78 @@ go.utils = {
     },
 
     opt_out: function(im, contact, env, reason) {
+        // sms-inbound STOP
+            // api optout.optout
+            // unsubscribe_all
+            // metric | optout_on    = clinic/personal/chw +1
+            // metric | optout_cause = 'unknown' +1
+            // kv     | optout_total = +1
+            // kv     | optout_loss  = 0
+
+        // optout
+            // suffers baby loss
+                // signs up for loss messages
+                    // no previous optout
+                        // unsubscribe_all
+                        // subscribe to loss messages
+                        // metric | optout_on    = clinic/personal/chw +1
+                        // metric | optout_cause = miscarriage/babyloss/stillbirth +1
+                        //                       = unknown 0
+                        // kv     | optout_total = +1
+                        // kv     | optout_loss  = +1
+                        // kv     | signup = +1
+
+                    // previous optout
+                        // api opt_in.opt_in
+                        // subscribe to loss messages
+                        // metric | optout_on    = 0
+                        // metric | optout_cause = miscarriage/babyloss/stillbirth +1
+                        //                       = unknown -1
+                        // kv     | optout_total = 0
+                        // kv     | optout_loss  = +1
+                        // kv     | signup = +1
+
+
+                // doesn't sign up for loss messages
+                    // no previous optout
+                        // api optout.optout
+                        // unsubscribe_all
+                        // metric | optout_on    = clinic/personal/chw +1
+                        // metric | optout_cause = miscarriage/babyloss/stillbirth +1
+                        // kv     | optout_total = +1
+                        // kv     | optout_loss  = +1
+                        // kv     | signup = 0
+
+                    // previous optout
+                        // -
+                        // metric | optout_on    = 0
+                        // metric | optout_cause = miscarriage/babyloss/stillbirth +1
+                        //                       = unknown -1
+                        // kv     | optout_total = 0
+                        // kv     | optout_loss  = +1
+                        // kv     | signup = 0
+
+            // chooses not_useful / other
+                // no previous optout
+                    // api optout.optout
+                    // unsubscribe_all
+                    // metric | optout_on    = clinic/personal/chw +1
+                    // metric | optout_cause = not_useful/other +1
+                    // kv     | optout_total = +1
+                    // kv     | optout_loss  = 0
+
+                // previous optout
+                    // -
+                    // metric | optout_on    = 0
+                    // metric | optout_cause = not_useful/other +1
+                    //                       = unknown -1
+                    // kv     | optout_total = 0
+                    // kv     | optout_loss  = 0
+
+
+
+
+
         return Q.all([
             im.api_request('optout.optout', {
                 address_type: "msisdn",
@@ -1038,7 +1110,8 @@ go.utils = {
                 message_id: im.msg.message_id
             }),
             im.metrics.fire.inc([env, 'sum', 'optout_on', go.utils.get_reg_source(contact)].join('.'), {amount:1}),
-            im.metrics.fire.inc([env, 'sum', 'optout_cause', reason].join('.'), {amount:1})
+            im.metrics.fire.inc([env, 'sum', 'optout_cause', reason].join('.'), {amount:1}),
+            go.utils.incr_kv(im, [env, 'sum', 'optout', 'all'].join('.'))
         ]);
     },
 

--- a/go-app-servicerating.js
+++ b/go-app-servicerating.js
@@ -681,7 +681,7 @@ go.utils = {
             return Q.all([
                 im.metrics.fire.last([metric_prefix, 'percent_incomplete_registrations'].join('.'), percentage_incomplete),
                 im.metrics.fire.last([metric_prefix, 'percent_complete_registrations'].join('.'), percentage_complete),
-                im.metrics.fire.inc([env, 'sum', 'registrations'].join('.'), 1),
+                im.metrics.fire.inc([env, 'sum', 'registrations'].join('.'), {amount:1}),
                 go.utils.incr_kv(im, [env, 'sum', 'registrations'].join('.'))
             ]);
         });
@@ -1037,7 +1037,7 @@ go.utils = {
                 address_value: contact.msisdn,
                 message_id: im.msg.message_id
             }),
-            im.metrics.fire.inc([env, 'sum', 'optout', go.utils.get_reg_source(contact)].join('.'), 1)
+            im.metrics.fire.inc([env, 'sum', 'optout', go.utils.get_reg_source(contact)].join('.'), {amount:1})
         ]);
     },
 

--- a/go-app-servicerating.js
+++ b/go-app-servicerating.js
@@ -1037,7 +1037,7 @@ go.utils = {
                 address_value: contact.msisdn,
                 message_id: im.msg.message_id
             }),
-            im.metrics.fire.inc([env, 'sum', 'optout', go.utils.get_reg_source(contact)].join('.'), {amount:1}),
+            im.metrics.fire.inc([env, 'sum', 'optout_on', go.utils.get_reg_source(contact)].join('.'), {amount:1}),
             im.metrics.fire.inc([env, 'sum', 'optout_cause', reason].join('.'), {amount:1})
         ]);
     },

--- a/go-app-servicerating.js
+++ b/go-app-servicerating.js
@@ -670,7 +670,7 @@ go.utils = {
             });
     },
 
-    adjust_percentage_registrations: function(im, metric_prefix) {
+    adjust_percentage_registrations: function(im, metric_prefix, env) {
         return Q.all([
             go.utils.get_kv(im, [metric_prefix, 'no_incomplete_registrations'].join('.'), 0),
             go.utils.get_kv(im, [metric_prefix, 'no_complete_registrations'].join('.'), 0)
@@ -680,7 +680,8 @@ go.utils = {
             var percentage_complete = (no_complete / total_attempted) * 100;
             return Q.all([
                 im.metrics.fire.last([metric_prefix, 'percent_incomplete_registrations'].join('.'), percentage_incomplete),
-                im.metrics.fire.last([metric_prefix, 'percent_complete_registrations'].join('.'), percentage_complete)
+                im.metrics.fire.last([metric_prefix, 'percent_complete_registrations'].join('.'), percentage_complete),
+                im.metrics.fire.inc([env, 'sum', 'registrations'].join('.'), 1)
             ]);
         });
     },

--- a/go-app-smsinbound.js
+++ b/go-app-smsinbound.js
@@ -1030,14 +1030,15 @@ go.utils = {
         return reg_source;
     },
 
-    opt_out: function(im, contact, env) {
+    opt_out: function(im, contact, env, reason) {
         return Q.all([
             im.api_request('optout.optout', {
                 address_type: "msisdn",
                 address_value: contact.msisdn,
                 message_id: im.msg.message_id
             }),
-            im.metrics.fire.inc([env, 'sum', 'optout', go.utils.get_reg_source(contact)].join('.'), {amount:1})
+            im.metrics.fire.inc([env, 'sum', 'optout', go.utils.get_reg_source(contact)].join('.'), {amount:1}),
+            im.metrics.fire.inc([env, 'sum', 'optout_cause', reason].join('.'), {amount:1})
         ]);
     },
 
@@ -1296,7 +1297,7 @@ go.app = function() {
         self.states.add('states_opt_out_enter', function(name) {
             return Q
                 .all([
-                    go.utils.opt_out(self.im, self.contact, self.env),
+                    go.utils.opt_out(self.im, self.contact, self.env, 'unknown'),
                     go.utils.subscription_unsubscribe_all(self.contact, self.im)
                 ])
                 .then(function() {

--- a/go-app-smsinbound.js
+++ b/go-app-smsinbound.js
@@ -1018,7 +1018,7 @@ go.utils = {
             && im.user.state.name !== 'states_start';
     },
 
-    opt_out: function(im, contact, env) {
+    get_reg_source: function(contact) {
         // determine registration source with default 'unknown'
         var reg_source;
         var registration_options = ['clinic', 'chw', 'personal'];
@@ -1027,14 +1027,17 @@ go.utils = {
         } else {
             reg_source = contact.extra.is_registered_by;
         }
+        return reg_source;
+    },
 
+    opt_out: function(im, contact, env) {
         return Q.all([
             im.api_request('optout.optout', {
                 address_type: "msisdn",
                 address_value: contact.msisdn,
                 message_id: im.msg.message_id
             }),
-            im.metrics.fire.inc([env, 'sum', 'optout', reg_source].join('.'), 1)
+            im.metrics.fire.inc([env, 'sum', 'optout', go.utils.get_reg_source(contact)].join('.'), 1)
         ]);
     },
 

--- a/go-app-smsinbound.js
+++ b/go-app-smsinbound.js
@@ -1018,12 +1018,24 @@ go.utils = {
             && im.user.state.name !== 'states_start';
     },
 
-    opt_out: function(im, contact) {
-        return im.api_request('optout.optout', {
-            address_type: "msisdn",
-            address_value: contact.msisdn,
-            message_id: im.msg.message_id
-        });
+    opt_out: function(im, contact, env) {
+        // determine registration source with default 'unknown'
+        var reg_source;
+        var registration_options = ['clinic', 'chw', 'personal'];
+        if (!_.contains(registration_options, contact.extra.is_registered_by)) {
+            reg_source = 'unknown';
+        } else {
+            reg_source = contact.extra.is_registered_by;
+        }
+
+        return Q.all([
+            im.api_request('optout.optout', {
+                address_type: "msisdn",
+                address_value: contact.msisdn,
+                message_id: im.msg.message_id
+            }),
+            im.metrics.fire.inc([env, 'sum', 'optout', reg_source].join('.'), 1)
+        ]);
     },
 
     opted_out: function(im, contact) {
@@ -1281,7 +1293,7 @@ go.app = function() {
         self.states.add('states_opt_out_enter', function(name) {
             return Q
                 .all([
-                    go.utils.opt_out(self.im, self.contact),
+                    go.utils.opt_out(self.im, self.contact, self.env),
                     go.utils.subscription_unsubscribe_all(self.contact, self.im)
                 ])
                 .then(function() {

--- a/go-app-smsinbound.js
+++ b/go-app-smsinbound.js
@@ -681,7 +681,8 @@ go.utils = {
             return Q.all([
                 im.metrics.fire.last([metric_prefix, 'percent_incomplete_registrations'].join('.'), percentage_incomplete),
                 im.metrics.fire.last([metric_prefix, 'percent_complete_registrations'].join('.'), percentage_complete),
-                im.metrics.fire.inc([env, 'sum', 'registrations'].join('.'), 1)
+                im.metrics.fire.inc([env, 'sum', 'registrations'].join('.'), 1),
+                go.utils.incr_kv(im, [env, 'sum', 'registrations'].join('.'))
             ]);
         });
     },

--- a/go-app-smsinbound.js
+++ b/go-app-smsinbound.js
@@ -681,7 +681,7 @@ go.utils = {
             return Q.all([
                 im.metrics.fire.last([metric_prefix, 'percent_incomplete_registrations'].join('.'), percentage_incomplete),
                 im.metrics.fire.last([metric_prefix, 'percent_complete_registrations'].join('.'), percentage_complete),
-                im.metrics.fire.inc([env, 'sum', 'registrations'].join('.'), 1),
+                im.metrics.fire.inc([env, 'sum', 'registrations'].join('.'), {amount:1}),
                 go.utils.incr_kv(im, [env, 'sum', 'registrations'].join('.'))
             ]);
         });
@@ -1037,7 +1037,7 @@ go.utils = {
                 address_value: contact.msisdn,
                 message_id: im.msg.message_id
             }),
-            im.metrics.fire.inc([env, 'sum', 'optout', go.utils.get_reg_source(contact)].join('.'), 1)
+            im.metrics.fire.inc([env, 'sum', 'optout', go.utils.get_reg_source(contact)].join('.'), {amount:1})
         ]);
     },
 

--- a/go-app-smsinbound.js
+++ b/go-app-smsinbound.js
@@ -1037,7 +1037,7 @@ go.utils = {
                 address_value: contact.msisdn,
                 message_id: im.msg.message_id
             }),
-            im.metrics.fire.inc([env, 'sum', 'optout', go.utils.get_reg_source(contact)].join('.'), {amount:1}),
+            im.metrics.fire.inc([env, 'sum', 'optout_on', go.utils.get_reg_source(contact)].join('.'), {amount:1}),
             im.metrics.fire.inc([env, 'sum', 'optout_cause', reason].join('.'), {amount:1})
         ]);
     },

--- a/go-app-smsinbound.js
+++ b/go-app-smsinbound.js
@@ -670,7 +670,7 @@ go.utils = {
             });
     },
 
-    adjust_percentage_registrations: function(im, metric_prefix) {
+    adjust_percentage_registrations: function(im, metric_prefix, env) {
         return Q.all([
             go.utils.get_kv(im, [metric_prefix, 'no_incomplete_registrations'].join('.'), 0),
             go.utils.get_kv(im, [metric_prefix, 'no_complete_registrations'].join('.'), 0)
@@ -680,7 +680,8 @@ go.utils = {
             var percentage_complete = (no_complete / total_attempted) * 100;
             return Q.all([
                 im.metrics.fire.last([metric_prefix, 'percent_incomplete_registrations'].join('.'), percentage_incomplete),
-                im.metrics.fire.last([metric_prefix, 'percent_complete_registrations'].join('.'), percentage_complete)
+                im.metrics.fire.last([metric_prefix, 'percent_complete_registrations'].join('.'), percentage_complete),
+                im.metrics.fire.inc([env, 'sum', 'registrations'].join('.'), 1)
             ]);
         });
     },

--- a/src/chw.js
+++ b/src/chw.js
@@ -297,7 +297,7 @@ go.app = function() {
                         return go.utils
                             .incr_kv(self.im, [self.store_name, 'no_incomplete_registrations'].join('.'))
                             .then(function() {
-                                return go.utils.adjust_percentage_registrations(self.im, self.metric_prefix);
+                                return go.utils.adjust_percentage_registrations(self.im, self.metric_prefix, self.env);
                             });
                     }
                 }
@@ -519,7 +519,7 @@ go.app = function() {
                                         go.utils.decr_kv(self.im, [self.store_name, 'no_incomplete_registrations'].join('.'))
                                     ])
                                         .then(function() {
-                                            return go.utils.adjust_percentage_registrations(self.im, self.metric_prefix);
+                                            return go.utils.adjust_percentage_registrations(self.im, self.metric_prefix, self.env);
                                         });
                                 })
                                 .then(function() {

--- a/src/clinic.js
+++ b/src/clinic.js
@@ -275,7 +275,7 @@ go.app = function() {
                         return go.utils
                             .incr_kv(self.im, [self.store_name, 'no_incomplete_registrations'].join('.'))
                             .then(function() {
-                                return go.utils.adjust_percentage_registrations(self.im, self.metric_prefix);
+                                return go.utils.adjust_percentage_registrations(self.im, self.metric_prefix, self.env);
                             });
                     }
                 }
@@ -620,7 +620,7 @@ go.app = function() {
                                         go.utils.decr_kv(self.im, [self.store_name, 'no_incomplete_registrations'].join('.'))
                                     ])
                                         .then(function() {
-                                            return go.utils.adjust_percentage_registrations(self.im, self.metric_prefix);
+                                            return go.utils.adjust_percentage_registrations(self.im, self.metric_prefix, self.env);
                                         });
                                 })
                                 .then(function() {

--- a/src/optout.js
+++ b/src/optout.js
@@ -119,7 +119,7 @@ go.app = function() {
                                             });
                                     } else {
                                         return self.im.metrics.fire
-                                            .inc([self.env, 'sum', 'optout', go.utils.get_reg_source(self.contact)].join('.'), {amount:1})
+                                            .inc([self.env, 'sum', 'optout_on', go.utils.get_reg_source(self.contact)].join('.'), {amount:1})
                                             .then(function() {
                                                 return 'states_end_yes';
                                             });

--- a/src/optout.js
+++ b/src/optout.js
@@ -129,7 +129,7 @@ go.app = function() {
                 events: {
                     'state:enter': function() {
                         return go.utils
-                            .opt_out(self.im, self.contact)
+                            .opt_out(self.im, self.contact, self.env)
                             .then(function() {
                                 return go.utils.subscription_unsubscribe_all(self.contact, self.im);
                             });

--- a/src/optout.js
+++ b/src/optout.js
@@ -35,6 +35,7 @@ go.app = function() {
                             if (json_result.opted_out === false) {
                                 question = $('Please let us know why you do not want MomConnect messages');
                             } else {
+                                self.contact.extra.prior_opt_out = 'true';
                                 question = $('Please tell us why you previously opted out of messages');
                             }
 
@@ -56,7 +57,11 @@ go.app = function() {
                                         .save(self.contact)
                                         .then(function() {
                                             if (_.contains(['not_useful', 'other'], choice.value)){
-                                                return 'states_end_no';
+                                                if (self.contact.extra.prior_opt_out === 'true') {
+                                                    return 'states_end_no';
+                                                } else {
+                                                    return 'states_end_no_optout';
+                                                }
                                             } else {
                                                 return 'states_subscribe_option';
                                             }
@@ -108,14 +113,27 @@ go.app = function() {
                         return go.utils
                             .jembi_send_json(self.contact, self.contact, 'subscription', self.im, self.metric_prefix)
                             .then(function() {
-                                return choice.value;
+                                if (self.contact.extra.prior_opt_out === 'true') {
+                                    return 'states_end_no';
+                                } else {
+                                    return 'states_end_no_optout';
+                                }
                             });
                     }
-
-
                 }
-
             });
+        });
+
+        self.states.add('states_end_no_optout', function(name) {
+            return go.utils
+                .opt_out(self.im, self.contact, self.env)
+                .then(function() {
+                    return go.utils
+                        .subscription_unsubscribe_all(self.contact, self.im)
+                        .then(function() {
+                            return self.states.create('states_end_no');
+                        });
+                });
         });
 
         self.states.add('states_end_no', function(name) {
@@ -124,17 +142,7 @@ go.app = function() {
                         'messages from us. If you have any medical ' +
                         'concerns please visit your nearest clinic.'),
 
-                next: 'states_start',
-
-                events: {
-                    'state:enter': function() {
-                        return go.utils
-                            .opt_out(self.im, self.contact, self.env)
-                            .then(function() {
-                                return go.utils.subscription_unsubscribe_all(self.contact, self.im);
-                            });
-                    }
-                },
+                next: 'states_start'
             });
         });
 

--- a/src/optout.js
+++ b/src/optout.js
@@ -58,7 +58,11 @@ go.app = function() {
                                         .then(function() {
                                             if (_.contains(['not_useful', 'other'], choice.value)){
                                                 if (self.contact.extra.prior_opt_out === 'true') {
-                                                    return 'states_end_no';
+                                                    return self.im.metrics.fire
+                                                        .inc([self.env, 'sum', 'optout_cause', 'unknown'].join('.'), {amount:-1}) // decrease unknown opt_outs
+                                                        .then(function() {
+                                                            return 'states_end_no_optout';
+                                                        });
                                                 } else {
                                                     return 'states_end_no_optout';
                                                 }
@@ -104,10 +108,15 @@ go.app = function() {
                                     go.utils.opt_in(self.im, self.contact),
                                     // activate new subscription
                                     go.utils.subscription_send_doc(self.contact, self.im, self.metric_prefix, opts),
+                                    self.im.metrics.fire.inc([self.env, 'sum', 'optout_cause', self.contact.extra.opt_out_reason].join('.'), {amount:1}),
                                     self.im.contacts.save(self.contact)
                                 ]).then(function() {
                                     if (self.contact.extra.prior_opt_out === 'true') {
-                                        return 'states_end_yes';
+                                        return self.im.metrics.fire
+                                            .inc([self.env, 'sum', 'optout_cause', 'unknown'].join('.'), {amount:-1}) // decrease unknown opt_outs
+                                            .then(function() {
+                                                return 'states_end_yes';
+                                            });
                                     } else {
                                         return self.im.metrics.fire
                                             .inc([self.env, 'sum', 'optout', go.utils.get_reg_source(self.contact)].join('.'), {amount:1})
@@ -134,7 +143,7 @@ go.app = function() {
 
         self.states.add('states_end_no_optout', function(name) {
             return go.utils
-                .opt_out(self.im, self.contact, self.env)
+                .opt_out(self.im, self.contact, self.env, self.contact.extra.opt_out_reason)
                 .then(function() {
                     return go.utils
                         .subscription_unsubscribe_all(self.contact, self.im)

--- a/src/optout.js
+++ b/src/optout.js
@@ -110,7 +110,7 @@ go.app = function() {
                                         return 'states_end_yes';
                                     } else {
                                         return self.im.metrics.fire
-                                            .inc([self.env, 'sum', 'optout', go.utils.get_reg_source(self.contact)].join('.'), 1)
+                                            .inc([self.env, 'sum', 'optout', go.utils.get_reg_source(self.contact)].join('.'), {amount:1})
                                             .then(function() {
                                                 return 'states_end_yes';
                                             });

--- a/src/optout.js
+++ b/src/optout.js
@@ -106,7 +106,15 @@ go.app = function() {
                                     go.utils.subscription_send_doc(self.contact, self.im, self.metric_prefix, opts),
                                     self.im.contacts.save(self.contact)
                                 ]).then(function() {
-                                    return choice.value;
+                                    if (self.contact.extra.prior_opt_out === 'true') {
+                                        return 'states_end_yes';
+                                    } else {
+                                        return self.im.metrics.fire
+                                            .inc([self.env, 'sum', 'optout', go.utils.get_reg_source(self.contact)].join('.'), 1)
+                                            .then(function() {
+                                                return 'states_end_yes';
+                                            });
+                                    }
                                 });
                             });
                     } else {

--- a/src/personal.js
+++ b/src/personal.js
@@ -334,9 +334,9 @@ go.app = function() {
                                     if (!self.im.config.faq_enabled && !self.im.config.detailed_data_collection){
                                         return 'states_suspect_pregnancy';
                                     } else {
-                                        return 'states_register_info'; 
+                                        return 'states_register_info';
                                     }
-                                    
+
                                 });
                         });
                 },
@@ -346,7 +346,7 @@ go.app = function() {
                         return go.utils
                             .incr_kv(self.im, [self.store_name, 'no_incomplete_registrations'].join('.'))
                             .then(function() {
-                                return go.utils.adjust_percentage_registrations(self.im, self.metric_prefix);
+                                return go.utils.adjust_percentage_registrations(self.im, self.metric_prefix, self.env);
                             });
                     }
                 }
@@ -700,7 +700,7 @@ go.app = function() {
                 self.im.contacts.save(self.contact)
             ])
             .then(function() {
-                return go.utils.adjust_percentage_registrations(self.im, self.metric_prefix);
+                return go.utils.adjust_percentage_registrations(self.im, self.metric_prefix, self.env);
             })
             .then(function() {
                 return self.states.create('states_end_success');

--- a/src/smsinbound.js
+++ b/src/smsinbound.js
@@ -66,7 +66,7 @@ go.app = function() {
         self.states.add('states_opt_out_enter', function(name) {
             return Q
                 .all([
-                    go.utils.opt_out(self.im, self.contact, self.env),
+                    go.utils.opt_out(self.im, self.contact, self.env, 'unknown'),
                     go.utils.subscription_unsubscribe_all(self.contact, self.im)
                 ])
                 .then(function() {

--- a/src/smsinbound.js
+++ b/src/smsinbound.js
@@ -64,10 +64,13 @@ go.app = function() {
         });
 
         self.states.add('states_opt_out_enter', function(name) {
+            var reason = 'unknown';
+            self.contact.extra.opt_out_reason = reason;
             return Q
                 .all([
-                    go.utils.opt_out(self.im, self.contact, self.env, 'unknown'),
-                    go.utils.subscription_unsubscribe_all(self.contact, self.im)
+                    go.utils.opt_out(self.im, self.contact, self.env, reason),
+                    go.utils.subscription_unsubscribe_all(self.contact, self.im),
+                    self.im.contacts.save(self.contact)
                 ])
                 .then(function() {
                     return self.states.create('states_opt_out');

--- a/src/smsinbound.js
+++ b/src/smsinbound.js
@@ -66,7 +66,7 @@ go.app = function() {
         self.states.add('states_opt_out_enter', function(name) {
             return Q
                 .all([
-                    go.utils.opt_out(self.im, self.contact),
+                    go.utils.opt_out(self.im, self.contact, self.env),
                     go.utils.subscription_unsubscribe_all(self.contact, self.im)
                 ])
                 .then(function() {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1015,7 +1015,7 @@ go.utils = {
             && im.user.state.name !== 'states_start';
     },
 
-    opt_out: function(im, contact, env) {
+    get_reg_source: function(contact) {
         // determine registration source with default 'unknown'
         var reg_source;
         var registration_options = ['clinic', 'chw', 'personal'];
@@ -1024,14 +1024,17 @@ go.utils = {
         } else {
             reg_source = contact.extra.is_registered_by;
         }
+        return reg_source;
+    },
 
+    opt_out: function(im, contact, env) {
         return Q.all([
             im.api_request('optout.optout', {
                 address_type: "msisdn",
                 address_value: contact.msisdn,
                 message_id: im.msg.message_id
             }),
-            im.metrics.fire.inc([env, 'sum', 'optout', reg_source].join('.'), 1)
+            im.metrics.fire.inc([env, 'sum', 'optout', go.utils.get_reg_source(contact)].join('.'), 1)
         ]);
     },
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -678,7 +678,8 @@ go.utils = {
             return Q.all([
                 im.metrics.fire.last([metric_prefix, 'percent_incomplete_registrations'].join('.'), percentage_incomplete),
                 im.metrics.fire.last([metric_prefix, 'percent_complete_registrations'].join('.'), percentage_complete),
-                im.metrics.fire.inc([env, 'sum', 'registrations'].join('.'), 1)
+                im.metrics.fire.inc([env, 'sum', 'registrations'].join('.'), 1),
+                go.utils.incr_kv(im, [env, 'sum', 'registrations'].join('.'))
             ]);
         });
     },

--- a/src/utils.js
+++ b/src/utils.js
@@ -667,7 +667,7 @@ go.utils = {
             });
     },
 
-    adjust_percentage_registrations: function(im, metric_prefix) {
+    adjust_percentage_registrations: function(im, metric_prefix, env) {
         return Q.all([
             go.utils.get_kv(im, [metric_prefix, 'no_incomplete_registrations'].join('.'), 0),
             go.utils.get_kv(im, [metric_prefix, 'no_complete_registrations'].join('.'), 0)
@@ -677,7 +677,8 @@ go.utils = {
             var percentage_complete = (no_complete / total_attempted) * 100;
             return Q.all([
                 im.metrics.fire.last([metric_prefix, 'percent_incomplete_registrations'].join('.'), percentage_incomplete),
-                im.metrics.fire.last([metric_prefix, 'percent_complete_registrations'].join('.'), percentage_complete)
+                im.metrics.fire.last([metric_prefix, 'percent_complete_registrations'].join('.'), percentage_complete),
+                im.metrics.fire.inc([env, 'sum', 'registrations'].join('.'), 1)
             ]);
         });
     },

--- a/src/utils.js
+++ b/src/utils.js
@@ -1034,7 +1034,7 @@ go.utils = {
                 address_value: contact.msisdn,
                 message_id: im.msg.message_id
             }),
-            im.metrics.fire.inc([env, 'sum', 'optout', go.utils.get_reg_source(contact)].join('.'), {amount:1}),
+            im.metrics.fire.inc([env, 'sum', 'optout_on', go.utils.get_reg_source(contact)].join('.'), {amount:1}),
             im.metrics.fire.inc([env, 'sum', 'optout_cause', reason].join('.'), {amount:1})
         ]);
     },

--- a/src/utils.js
+++ b/src/utils.js
@@ -1027,14 +1027,15 @@ go.utils = {
         return reg_source;
     },
 
-    opt_out: function(im, contact, env) {
+    opt_out: function(im, contact, env, reason) {
         return Q.all([
             im.api_request('optout.optout', {
                 address_type: "msisdn",
                 address_value: contact.msisdn,
                 message_id: im.msg.message_id
             }),
-            im.metrics.fire.inc([env, 'sum', 'optout', go.utils.get_reg_source(contact)].join('.'), {amount:1})
+            im.metrics.fire.inc([env, 'sum', 'optout', go.utils.get_reg_source(contact)].join('.'), {amount:1}),
+            im.metrics.fire.inc([env, 'sum', 'optout_cause', reason].join('.'), {amount:1})
         ]);
     },
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -678,7 +678,7 @@ go.utils = {
             return Q.all([
                 im.metrics.fire.last([metric_prefix, 'percent_incomplete_registrations'].join('.'), percentage_incomplete),
                 im.metrics.fire.last([metric_prefix, 'percent_complete_registrations'].join('.'), percentage_complete),
-                im.metrics.fire.inc([env, 'sum', 'registrations'].join('.'), 1),
+                im.metrics.fire.inc([env, 'sum', 'registrations'].join('.'), {amount:1}),
                 go.utils.incr_kv(im, [env, 'sum', 'registrations'].join('.'))
             ]);
         });
@@ -1034,7 +1034,7 @@ go.utils = {
                 address_value: contact.msisdn,
                 message_id: im.msg.message_id
             }),
-            im.metrics.fire.inc([env, 'sum', 'optout', go.utils.get_reg_source(contact)].join('.'), 1)
+            im.metrics.fire.inc([env, 'sum', 'optout', go.utils.get_reg_source(contact)].join('.'), {amount:1})
         ]);
     },
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1015,12 +1015,24 @@ go.utils = {
             && im.user.state.name !== 'states_start';
     },
 
-    opt_out: function(im, contact) {
-        return im.api_request('optout.optout', {
-            address_type: "msisdn",
-            address_value: contact.msisdn,
-            message_id: im.msg.message_id
-        });
+    opt_out: function(im, contact, env) {
+        // determine registration source with default 'unknown'
+        var reg_source;
+        var registration_options = ['clinic', 'chw', 'personal'];
+        if (!_.contains(registration_options, contact.extra.is_registered_by)) {
+            reg_source = 'unknown';
+        } else {
+            reg_source = contact.extra.is_registered_by;
+        }
+
+        return Q.all([
+            im.api_request('optout.optout', {
+                address_type: "msisdn",
+                address_value: contact.msisdn,
+                message_id: im.msg.message_id
+            }),
+            im.metrics.fire.inc([env, 'sum', 'optout', reg_source].join('.'), 1)
+        ]);
     },
 
     opted_out: function(im, contact) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1028,6 +1028,78 @@ go.utils = {
     },
 
     opt_out: function(im, contact, env, reason) {
+        // sms-inbound STOP
+            // api optout.optout
+            // unsubscribe_all
+            // metric | optout_on    = clinic/personal/chw +1
+            // metric | optout_cause = 'unknown' +1
+            // kv     | optout_total = +1
+            // kv     | optout_loss  = 0
+
+        // optout
+            // suffers baby loss
+                // signs up for loss messages
+                    // no previous optout
+                        // unsubscribe_all
+                        // subscribe to loss messages
+                        // metric | optout_on    = clinic/personal/chw +1
+                        // metric | optout_cause = miscarriage/babyloss/stillbirth +1
+                        //                       = unknown 0
+                        // kv     | optout_total = +1
+                        // kv     | optout_loss  = +1
+                        // kv     | signup = +1
+
+                    // previous optout
+                        // api opt_in.opt_in
+                        // subscribe to loss messages
+                        // metric | optout_on    = 0
+                        // metric | optout_cause = miscarriage/babyloss/stillbirth +1
+                        //                       = unknown -1
+                        // kv     | optout_total = 0
+                        // kv     | optout_loss  = +1
+                        // kv     | signup = +1
+
+
+                // doesn't sign up for loss messages
+                    // no previous optout
+                        // api optout.optout
+                        // unsubscribe_all
+                        // metric | optout_on    = clinic/personal/chw +1
+                        // metric | optout_cause = miscarriage/babyloss/stillbirth +1
+                        // kv     | optout_total = +1
+                        // kv     | optout_loss  = +1
+                        // kv     | signup = 0
+
+                    // previous optout
+                        // -
+                        // metric | optout_on    = 0
+                        // metric | optout_cause = miscarriage/babyloss/stillbirth +1
+                        //                       = unknown -1
+                        // kv     | optout_total = 0
+                        // kv     | optout_loss  = +1
+                        // kv     | signup = 0
+
+            // chooses not_useful / other
+                // no previous optout
+                    // api optout.optout
+                    // unsubscribe_all
+                    // metric | optout_on    = clinic/personal/chw +1
+                    // metric | optout_cause = not_useful/other +1
+                    // kv     | optout_total = +1
+                    // kv     | optout_loss  = 0
+
+                // previous optout
+                    // -
+                    // metric | optout_on    = 0
+                    // metric | optout_cause = not_useful/other +1
+                    //                       = unknown -1
+                    // kv     | optout_total = 0
+                    // kv     | optout_loss  = 0
+
+
+
+
+
         return Q.all([
             im.api_request('optout.optout', {
                 address_type: "msisdn",
@@ -1035,7 +1107,8 @@ go.utils = {
                 message_id: im.msg.message_id
             }),
             im.metrics.fire.inc([env, 'sum', 'optout_on', go.utils.get_reg_source(contact)].join('.'), {amount:1}),
-            im.metrics.fire.inc([env, 'sum', 'optout_cause', reason].join('.'), {amount:1})
+            im.metrics.fire.inc([env, 'sum', 'optout_cause', reason].join('.'), {amount:1}),
+            go.utils.incr_kv(im, [env, 'sum', 'optout', 'all'].join('.'))
         ]);
     },
 

--- a/test/chw.test.js
+++ b/test/chw.test.js
@@ -1469,6 +1469,7 @@ describe("app", function() {
                             assert.deepEqual(metrics['test.chw.percent_incomplete_registrations'].values, [25]);
                             assert.deepEqual(metrics['test.chw.percent_complete_registrations'].values, [75]);
                             assert.deepEqual(metrics['test.chw.sum.json_to_jembi_success'].values, [1]);
+                            assert.deepEqual(metrics['test.sum.registrations'].values, [1]);
                         })
                         .check.reply.ends_session()
                         .run();
@@ -1587,6 +1588,7 @@ describe("app", function() {
                             assert.deepEqual(metrics['test.chw.percent_incomplete_registrations'].values, [25]);
                             assert.deepEqual(metrics['test.chw.percent_complete_registrations'].values, [75]);
                             assert.deepEqual(metrics['test.chw.sum.json_to_jembi_success'].values, [1]);
+                            assert.deepEqual(metrics['test.sum.registrations'].values, [1]);
                         })
                         .check.reply.ends_session()
                         .run();

--- a/test/chw.test.js
+++ b/test/chw.test.js
@@ -87,6 +87,8 @@ describe("app", function() {
                     api.kv.store['test.personal.unique_users'] = 0;
                     api.kv.store['test.chw.no_complete_registrations'] = 2;
                     api.kv.store['test.chw.no_incomplete_registrations'] = 2;
+                    api.kv.store['test.sum.registrations'] = 3;
+                    api.kv.store['test.clinic.no_complete_registrations'] = 1;
                 })
                 .setup(function(api) {
                     api.metrics.stores = {'test_metric_store': {}};
@@ -1465,11 +1467,13 @@ describe("app", function() {
                         })
                         .check(function(api) {
                             var metrics = api.metrics.stores.test_metric_store;
+                            var kv_store = api.kv.store;
                             assert.deepEqual(metrics['test.chw.avg.sessions_to_register'].values, [5]);
                             assert.deepEqual(metrics['test.chw.percent_incomplete_registrations'].values, [25]);
                             assert.deepEqual(metrics['test.chw.percent_complete_registrations'].values, [75]);
                             assert.deepEqual(metrics['test.chw.sum.json_to_jembi_success'].values, [1]);
                             assert.deepEqual(metrics['test.sum.registrations'].values, [1]);
+                            assert.equal(kv_store['test.sum.registrations'], 4);
                         })
                         .check.reply.ends_session()
                         .run();
@@ -1584,11 +1588,13 @@ describe("app", function() {
                         })
                         .check(function(api) {
                             var metrics = api.metrics.stores.test_metric_store;
+                            var kv_store = api.kv.store;
                             assert.deepEqual(metrics['test.chw.avg.sessions_to_register'].values, [5]);
                             assert.deepEqual(metrics['test.chw.percent_incomplete_registrations'].values, [25]);
                             assert.deepEqual(metrics['test.chw.percent_complete_registrations'].values, [75]);
                             assert.deepEqual(metrics['test.chw.sum.json_to_jembi_success'].values, [1]);
                             assert.deepEqual(metrics['test.sum.registrations'].values, [1]);
+                            assert.equal(kv_store['test.sum.registrations'], 4);
                         })
                         .check.reply.ends_session()
                         .run();

--- a/test/clinic.test.js
+++ b/test/clinic.test.js
@@ -169,6 +169,8 @@ describe("app", function() {
                     api.kv.store['test.personal.unique_users'] = 0;
                     api.kv.store['test.clinic.no_complete_registrations'] = 2;
                     api.kv.store['test.clinic.no_incomplete_registrations'] = 2;
+                    api.kv.store['test.sum.registrations'] = 3;
+                    api.kv.store['test.chw.no_complete_registrations'] = 1;
                 })
                 .setup(function(api) {
                     api.metrics.stores = {'test_metric_store': {}};
@@ -1605,6 +1607,7 @@ describe("app", function() {
                         })
                         .check(function(api) {
                             var metrics = api.metrics.stores.test_metric_store;
+                            var kv_store = api.kv.store;
                             assert.deepEqual(metrics['test.clinic.avg.sessions_to_register'].values, [5]);
                             assert.deepEqual(metrics['test.clinic.percent_incomplete_registrations'].values, [25]);
                             assert.deepEqual(metrics['test.clinic.percent_complete_registrations'].values, [75]);
@@ -1612,6 +1615,7 @@ describe("app", function() {
                             assert.deepEqual(metrics['test.clinic.sum.doc_to_jembi_success'].values, [1]);
                             assert.deepEqual(metrics['test.clinic.sum.json_to_jembi_success'].values, [1]);
                             assert.deepEqual(metrics['test.sum.registrations'].values, [1]);
+                            assert.equal(kv_store['test.sum.registrations'], 4);
                         })
                         .check.reply.ends_session()
                         .run();
@@ -1782,6 +1786,7 @@ describe("app", function() {
                         })
                         .check(function(api) {
                             var metrics = api.metrics.stores.test_metric_store;
+                            var kv_store = api.kv.store;
                             assert.deepEqual(metrics['test.clinic.avg.sessions_to_register'].values, [5]);
                             assert.deepEqual(metrics['test.clinic.percent_incomplete_registrations'].values, [25]);
                             assert.deepEqual(metrics['test.clinic.percent_complete_registrations'].values, [75]);
@@ -1789,6 +1794,7 @@ describe("app", function() {
                             assert.deepEqual(metrics['test.clinic.sum.doc_to_jembi_success'], undefined);
                             assert.deepEqual(metrics['test.clinic.sum.json_to_jembi_success'].values, [1]);
                             assert.deepEqual(metrics['test.sum.registrations'].values, [1]);
+                            assert.equal(kv_store['test.sum.registrations'], 4);
                         })
                         .check.reply.ends_session()
                         .run();

--- a/test/clinic.test.js
+++ b/test/clinic.test.js
@@ -1611,7 +1611,7 @@ describe("app", function() {
                             assert.deepEqual(metrics['test.clinic.states_end_success.no_incomplete'], undefined);
                             assert.deepEqual(metrics['test.clinic.sum.doc_to_jembi_success'].values, [1]);
                             assert.deepEqual(metrics['test.clinic.sum.json_to_jembi_success'].values, [1]);
-
+                            assert.deepEqual(metrics['test.sum.registrations'].values, [1]);
                         })
                         .check.reply.ends_session()
                         .run();
@@ -1788,6 +1788,7 @@ describe("app", function() {
                             assert.deepEqual(metrics['test.clinic.states_end_success.no_incomplete'], undefined);
                             assert.deepEqual(metrics['test.clinic.sum.doc_to_jembi_success'], undefined);
                             assert.deepEqual(metrics['test.clinic.sum.json_to_jembi_success'].values, [1]);
+                            assert.deepEqual(metrics['test.sum.registrations'].values, [1]);
                         })
                         .check.reply.ends_session()
                         .run();

--- a/test/optout.test.js
+++ b/test/optout.test.js
@@ -158,14 +158,14 @@ describe("app", function() {
                         .run();
                 });
 
-                it("should fire metrics if is_registered_by undefined", function() {
+                it("should not fire metrics if previously opted out", function() {
                     return tester
                         .setup.user.addr('27831112222')
                         .setup.user.state('states_start')
                         .input('4')
                         .check(function(api) {
                             var metrics = api.metrics.stores.test_metric_store;
-                            assert.deepEqual(metrics['test.sum.optout.unknown'].values, [1]);
+                            assert.deepEqual(metrics, undefined);
                         })
                         .run();
                 });

--- a/test/optout.test.js
+++ b/test/optout.test.js
@@ -73,7 +73,8 @@ describe("app", function() {
                             id_type: 'passport',
                             passport_origin: 'zw',
                             passport_no: '12345',
-                            ussd_sessions: '5'
+                            ussd_sessions: '5',
+                            is_registered_by: 'chw'
                         },
                         key: "63ee4fa9-6888-4f0c-065a-939dc2473a99",
                         user_account: "4a11907a-4cc4-415a-9011-58251e15e2b4"
@@ -101,6 +102,7 @@ describe("app", function() {
                 });
         });
 
+        // METRICS
         describe('using the session length helper', function () {
             it('should publish metrics', function () {
                 return tester
@@ -139,6 +141,34 @@ describe("app", function() {
                         assert.equal(
                           m_store['session_length_helper.' + im.config.name + '.foodacom'].values[0], 60);
                     }).run();
+            });
+        });
+
+        describe('test metric firing:', function() {
+            describe('when the user is opted out', function() {
+                it("should fire metrics if is_registered_by defined", function() {
+                    return tester
+                        .setup.user.addr('27001')
+                        .setup.user.state('states_start')
+                        .input('4')
+                        .check(function(api) {
+                            var metrics = api.metrics.stores.test_metric_store;
+                            assert.deepEqual(metrics['test.sum.optout.chw'].values, [1]);
+                        })
+                        .run();
+                });
+
+                it("should fire metrics if is_registered_by undefined", function() {
+                    return tester
+                        .setup.user.addr('27831112222')
+                        .setup.user.state('states_start')
+                        .input('4')
+                        .check(function(api) {
+                            var metrics = api.metrics.stores.test_metric_store;
+                            assert.deepEqual(metrics['test.sum.optout.unknown'].values, [1]);
+                        })
+                        .run();
+                });
             });
         });
 

--- a/test/optout.test.js
+++ b/test/optout.test.js
@@ -153,7 +153,7 @@ describe("app", function() {
                         .input('4')
                         .check(function(api) {
                             var metrics = api.metrics.stores.test_metric_store;
-                            assert.deepEqual(metrics['test.sum.optout.chw'].values, [1]);
+                            assert.deepEqual(metrics['test.sum.optout_on.chw'].values, [1]);
                             assert.deepEqual(metrics['test.sum.optout_cause.not_useful'].values, [1]);
                         })
                         .run();
@@ -166,7 +166,7 @@ describe("app", function() {
                         .inputs('start', '1', '1')
                         .check(function(api) {
                             var metrics = api.metrics.stores.test_metric_store;
-                            assert.deepEqual(metrics['test.sum.optout.chw'].values, [1]);
+                            assert.deepEqual(metrics['test.sum.optout_on.chw'].values, [1]);
                             assert.deepEqual(metrics['test.sum.optout_cause.miscarriage'].values, [1]);
                         })
                         .run();
@@ -179,6 +179,7 @@ describe("app", function() {
                         .input('4')
                         .check(function(api) {
                             var metrics = api.metrics.stores.test_metric_store;
+                            assert.deepEqual(metrics['test.sum.optout_on'], undefined);
                             assert.deepEqual(metrics['test.sum.optout_cause.unknown'].values, [-1]);
                             assert.deepEqual(metrics['test.sum.optout_cause.not_useful'].values, [1]);
                         })
@@ -191,6 +192,7 @@ describe("app", function() {
                         .inputs('start', '1', '1')
                         .check(function(api) {
                             var metrics = api.metrics.stores.test_metric_store;
+                            assert.deepEqual(metrics['test.sum.optout_on'], undefined);
                             assert.deepEqual(metrics['test.sum.optout_cause.unknown'].values, [-1]);
                             assert.deepEqual(metrics['test.sum.optout_cause.miscarriage'].values, [1]);
                         })

--- a/test/optout.test.js
+++ b/test/optout.test.js
@@ -146,11 +146,23 @@ describe("app", function() {
 
         describe('test metric firing:', function() {
             describe('when the user is opted out', function() {
-                it("should fire metrics if is_registered_by defined", function() {
+                it("should fire metrics if no loss message signup", function() {
                     return tester
                         .setup.user.addr('27001')
                         .setup.user.state('states_start')
                         .input('4')
+                        .check(function(api) {
+                            var metrics = api.metrics.stores.test_metric_store;
+                            assert.deepEqual(metrics['test.sum.optout.chw'].values, [1]);
+                        })
+                        .run();
+                });
+
+                it("should fire metrics if loss message signup", function() {
+                    return tester
+                        .setup.user.addr('27001')
+                        .setup.user.state('states_start')
+                        .inputs('start', '1', '1')
                         .check(function(api) {
                             var metrics = api.metrics.stores.test_metric_store;
                             assert.deepEqual(metrics['test.sum.optout.chw'].values, [1]);
@@ -166,6 +178,17 @@ describe("app", function() {
                         .check(function(api) {
                             var metrics = api.metrics.stores.test_metric_store;
                             assert.deepEqual(metrics, undefined);
+                        })
+                        .run();
+                });
+
+                it("should not fire metrics if previously opted out and signs up", function() {
+                    return tester
+                        .setup.user.addr('27831112222')
+                        .inputs('start', '1', '1')
+                        .check(function(api) {
+                            var metrics = api.metrics.stores.test_metric_store;
+                            assert.equal(metrics['test.sum.optout.unknown'], undefined);
                         })
                         .run();
                 });

--- a/test/optout.test.js
+++ b/test/optout.test.js
@@ -145,7 +145,7 @@ describe("app", function() {
         });
 
         describe('test metric firing:', function() {
-            describe('when the user is opted out', function() {
+            describe('when the user opts out', function() {
                 it("should fire metrics if no loss message signup", function() {
                     return tester
                         .setup.user.addr('27001')
@@ -154,6 +154,7 @@ describe("app", function() {
                         .check(function(api) {
                             var metrics = api.metrics.stores.test_metric_store;
                             assert.deepEqual(metrics['test.sum.optout.chw'].values, [1]);
+                            assert.deepEqual(metrics['test.sum.optout_cause.not_useful'].values, [1]);
                         })
                         .run();
                 });
@@ -166,29 +167,32 @@ describe("app", function() {
                         .check(function(api) {
                             var metrics = api.metrics.stores.test_metric_store;
                             assert.deepEqual(metrics['test.sum.optout.chw'].values, [1]);
+                            assert.deepEqual(metrics['test.sum.optout_cause.miscarriage'].values, [1]);
                         })
                         .run();
                 });
 
-                it("should not fire metrics if previously opted out", function() {
+                it("should fire correct metrics if previously opted out and does not sign up", function() {
                     return tester
                         .setup.user.addr('27831112222')
                         .setup.user.state('states_start')
                         .input('4')
                         .check(function(api) {
                             var metrics = api.metrics.stores.test_metric_store;
-                            assert.deepEqual(metrics, undefined);
+                            assert.deepEqual(metrics['test.sum.optout_cause.unknown'].values, [-1]);
+                            assert.deepEqual(metrics['test.sum.optout_cause.not_useful'].values, [1]);
                         })
                         .run();
                 });
 
-                it("should not fire metrics if previously opted out and signs up", function() {
+                it("should fire metrics if previously opted out and signs up", function() {
                     return tester
                         .setup.user.addr('27831112222')
                         .inputs('start', '1', '1')
                         .check(function(api) {
                             var metrics = api.metrics.stores.test_metric_store;
-                            assert.equal(metrics['test.sum.optout.unknown'], undefined);
+                            assert.deepEqual(metrics['test.sum.optout_cause.unknown'].values, [-1]);
+                            assert.deepEqual(metrics['test.sum.optout_cause.miscarriage'].values, [1]);
                         })
                         .run();
                 });

--- a/test/personal.test.js
+++ b/test/personal.test.js
@@ -1357,6 +1357,7 @@ describe("app", function() {
                         assert.deepEqual(metrics['test.personal.percent_incomplete_registrations'].values, [25]);
                         assert.deepEqual(metrics['test.personal.percent_complete_registrations'].values, [75]);
                         assert.deepEqual(metrics['test.personal.sum.json_to_jembi_success'].values, [1]);
+                        assert.deepEqual(metrics['test.sum.registrations'].values, [1]);
                     })
                     .check(function(api) {
                         var smses = _.where(api.outbound.store, {

--- a/test/personal.test.js
+++ b/test/personal.test.js
@@ -103,6 +103,8 @@ describe("app", function() {
                     api.kv.store['test.personal.unique_users'] = 0;
                     api.kv.store['test.personal.no_complete_registrations'] = 2;
                     api.kv.store['test.personal.no_incomplete_registrations'] = 2;
+                    api.kv.store['test.sum.registrations'] = 3;
+                    api.kv.store['test.chw.no_complete_registrations'] = 1;
                 })
                 .setup(function(api) {
                     api.metrics.stores = {'test_metric_store': {}};
@@ -1353,11 +1355,13 @@ describe("app", function() {
                     })
                     .check(function(api) {
                         var metrics = api.metrics.stores.test_metric_store;
+                        var kv_store = api.kv.store;
                         assert.deepEqual(metrics['test.personal.avg.sessions_to_register'].values, [5]);
                         assert.deepEqual(metrics['test.personal.percent_incomplete_registrations'].values, [25]);
                         assert.deepEqual(metrics['test.personal.percent_complete_registrations'].values, [75]);
                         assert.deepEqual(metrics['test.personal.sum.json_to_jembi_success'].values, [1]);
                         assert.deepEqual(metrics['test.sum.registrations'].values, [1]);
+                        assert.equal(kv_store['test.sum.registrations'], 4);
                     })
                     .check(function(api) {
                         var smses = _.where(api.outbound.store, {

--- a/test/smsinbound.test.js
+++ b/test/smsinbound.test.js
@@ -269,6 +269,28 @@ describe("app", function() {
                     })
                     .run();
             });
+
+            it("should fire metrics", function() {
+                return tester
+                    .setup(function(api) {
+                        api.contacts.add({
+                            msisdn: '+27001',
+                            extra : {
+                                language_choice: 'en',
+                                is_registered_by: 'clinic'
+                            },
+                            key: "63ee4fa9-6888-4f0c-065a-939dc2473a99",
+                            user_account: "4a11907a-4cc4-415a-9011-58251e15e2b4"
+                        });
+                    })
+                    .setup.user.addr('27001')
+                    .input('stop please!')
+                    .check(function(api) {
+                        var metrics = api.metrics.stores.test_metric_store;
+                        assert.deepEqual(metrics['test.sum.optout.clinic'].values, [1]);
+                    })
+                    .run();
+            });
         });
 
         describe("when the user sends a BLOCK message", function() {

--- a/test/smsinbound.test.js
+++ b/test/smsinbound.test.js
@@ -288,6 +288,7 @@ describe("app", function() {
                     .check(function(api) {
                         var metrics = api.metrics.stores.test_metric_store;
                         assert.deepEqual(metrics['test.sum.optout.clinic'].values, [1]);
+                        assert.deepEqual(metrics['test.sum.optout_cause.unknown'].values, [1]);
                     })
                     .run();
             });

--- a/test/smsinbound.test.js
+++ b/test/smsinbound.test.js
@@ -287,7 +287,7 @@ describe("app", function() {
                     .input('stop please!')
                     .check(function(api) {
                         var metrics = api.metrics.stores.test_metric_store;
-                        assert.deepEqual(metrics['test.sum.optout.clinic'].values, [1]);
+                        assert.deepEqual(metrics['test.sum.optout_on.clinic'].values, [1]);
                         assert.deepEqual(metrics['test.sum.optout_cause.unknown'].values, [1]);
                     })
                     .run();


### PR DESCRIPTION
- [x] Total subscriptions `qa.sum.registrations`
- [x] % Opt outs of total subscriptions `qa.percent.optout.all`
- [x] % Opt outs (non loss) of total subscriptions `qa.percent.optout.non_loss`
- [x] % Loss opt outs who chose to get messages `qa.percent.loss_optout.messages`
- [x] Total switch to baby by SMS
- [x] Conversion rates to Clinic registrations
- [x] Opt outs per subscription source `qa.sum.optout_on.clinic`
- [x] Opt outs per reason `qa.sum.optout_cause.babyloss`
