### PR TITLE
Prevent multiple service ratings

### DIFF
--- a/go-app-servicerating.js
+++ b/go-app-servicerating.js
@@ -1611,7 +1611,9 @@ go.app = function() {
         };
 
         self.states.add('states_start', function(name) {
-            if (self.contact.extra.is_registered_by === 'clinic') {
+            if (self.contact.extra.last_service_rating !== undefined) {
+                return self.states.create('end_thanks_revisit');
+            } else if (self.contact.extra.is_registered_by === 'clinic') {
                 return go.utils
                     .incr_kv(self.im, [self.store_name, 'sum', 'servicerating_start'].join('.'))
                     .then(function() {

--- a/src/servicerating.js
+++ b/src/servicerating.js
@@ -56,7 +56,9 @@ go.app = function() {
         };
 
         self.states.add('states_start', function(name) {
-            if (self.contact.extra.is_registered_by === 'clinic') {
+            if (self.contact.extra.last_service_rating !== undefined) {
+                return self.states.create('end_thanks_revisit');
+            } else if (self.contact.extra.is_registered_by === 'clinic') {
                 return go.utils
                     .incr_kv(self.im, [self.store_name, 'sum', 'servicerating_start'].join('.'))
                     .then(function() {

--- a/test/servicerating.test.js
+++ b/test/servicerating.test.js
@@ -215,6 +215,34 @@ describe("app", function() {
                         .run();
                 });
             });
+
+            describe("when the user has already logged a servicerating", function() {
+                it("should tell them they can't do it again", function() {
+                    return tester
+                        .setup.user.addr('27001')
+                        .setup(function(api) {
+                            api.contacts.add({
+                                msisdn: '+27001',
+                                extra : {
+                                    language_choice: 'zu',
+                                    is_registered_by: 'clinic',
+                                    last_service_rating: '20130819144811'
+                                }
+                            });
+                        })
+                        .start()
+                        .check.interaction({
+                            state: 'end_thanks_revisit',
+                            reply: [
+                                'Sorry, you\'ve already rated service. For baby and pregnancy ' +
+                                'help or if you have compliments or complaints ' +
+                                'dial *120*550# or reply to any of the SMSs you receive'
+                            ].join('\n')
+                        })
+                        .check.reply.ends_session()
+                        .run();
+                });
+            });
         });
 
         describe("when the user answers their friendliness rating", function() {


### PR DESCRIPTION
With the change in Redis key handling, a user can now come back after 7 days and log another servicerating.
