### PR TITLE
Some tests fail in isolation

### DIFF
--- a/test/optout.test.js
+++ b/test/optout.test.js
@@ -499,7 +499,7 @@ describe("app", function() {
                 it("should ask for the reason they are opting out", function() {
                     return tester
                         .setup.user.addr('27001')
-                        .start()
+                        .inputs({session_event: "new"})
                         .check.interaction({
                             state: 'states_start',
                             reply: [
@@ -520,7 +520,7 @@ describe("app", function() {
                 it("should ask for the reason they are opting out", function() {
                     return tester
                         .setup.user.addr('27831112222')
-                        .start()
+                        .inputs({session_event: "new"})
                         .check.interaction({
                             state: 'states_start',
                             reply: [
@@ -543,8 +543,7 @@ describe("app", function() {
             it("should ask if they want further help", function() {
                 return tester
                     .setup.user.addr('27001')
-                    .setup.user.state('states_start')
-                    .input('1')
+                    .inputs({session_event: "new"}, '1')
                     .check.interaction({
                         state: 'states_subscribe_option',
                         reply: [
@@ -563,8 +562,7 @@ describe("app", function() {
             it("should thank them and exit", function() {
                 return tester
                     .setup.user.addr('27001')
-                    .setup.user.state('states_start')
-                    .input('4')
+                    .inputs({session_event: "new"}, '4')
                     .check.interaction({
                         state: 'states_end_no',
                         reply: ('Thank you. You will no longer receive ' +
@@ -578,8 +576,7 @@ describe("app", function() {
             it("should save their optout reason against their contact", function() {
                 return tester
                     .setup.user.addr('27001')
-                    .setup.user.state('states_start')
-                    .input('4')
+                    .inputs({session_event: "new"}, '4')
                     .check(function(api) {
                         var contact = api.contacts.store[0];
                         assert.equal(contact.extra.opt_out_reason, 'not_useful');
@@ -606,12 +603,8 @@ describe("app", function() {
                             user_account: "4a11907a-4cc4-415a-9011-58251e15e2b4"
                         });
                     })
-                    .setup.user.answers({
-                        'states_start': 'miscarriage'
-                    })
                     .setup.user.addr('27001')
-                    .setup.user.state('states_subscribe_option')
-                    .input('2')
+                    .inputs({session_event: "new"}, '1', '2')
                     .check.interaction({
                         state: 'states_end_no',
                         reply: ('Thank you. You will no longer receive ' +
@@ -639,12 +632,8 @@ describe("app", function() {
                             user_account: "4a11907a-4cc4-415a-9011-58251e15e2b4"
                         });
                     })
-                    .setup.user.answers({
-                        'states_start': 'miscarriage'
-                    })
                     .setup.user.addr('27001')
-                    .setup.user.state('states_subscribe_option')
-                    .input('2')
+                    .inputs({session_event: "new"}, '1', '2')
                     .check(function(api) {
                         var contact = api.contacts.store[0];
                         assert.equal(contact.extra.opt_out_reason, 'miscarriage');
@@ -658,12 +647,8 @@ describe("app", function() {
             describe("when the user has existing subscriptions", function() {
                 it("should unsubscribe from other lines, subscribe them and exit", function() {
                     return tester
-                        .setup.user.answers({
-                            'states_start': 'miscarriage'
-                        })
-                        .setup.user.state('states_subscribe_option')
                         .setup.user.addr('27001')
-                        .input('1')
+                        .inputs({session_event: "new"}, '1', '1')
                         .check.interaction({
                             state: 'states_end_yes',
                             reply: ('Thank you. You will receive support messages ' +
@@ -683,12 +668,8 @@ describe("app", function() {
                 it("should set their optout reason as '' since they opted in to babyloss " +
                    "messages", function() {
                     return tester
-                        .setup.user.answers({
-                            'states_start': 'miscarriage'
-                        })
-                        .setup.user.state('states_subscribe_option')
                         .setup.user.addr('27001')
-                        .input('1')
+                        .inputs({session_event: "new"}, '1', '1')
                         .check(function(api) {
                             var contact = _.find(api.contacts.store, {
                               msisdn: '+27001'
@@ -702,12 +683,8 @@ describe("app", function() {
             describe("when the user has no existing subscriptions", function() {
                 it("should subscribe them and exit", function() {
                     return tester
-                        .setup.user.answers({
-                            'states_start': 'miscarriage'
-                        })
-                        .setup.user.state('states_subscribe_option')
                         .setup.user.addr('27831112222')
-                        .input('1')
+                        .inputs({session_event: "new"}, '1', '1')
                         .check.interaction({
                             state: 'states_end_yes',
                             reply: ('Thank you. You will receive support messages ' +
@@ -727,12 +704,8 @@ describe("app", function() {
                 it("should set their optout reason as '' since they opted in to babyloss " +
                    "messages", function() {
                     return tester
-                        .setup.user.answers({
-                            'states_start': 'miscarriage'
-                        })
-                        .setup.user.state('states_subscribe_option')
                         .setup.user.addr('27831112222')
-                        .input('1')
+                        .inputs({session_event: "new"}, '1', '1')
                         .check(function(api) {
                             var contact = _.find(api.contacts.store, { msisdn: '+27831112222' });
                             assert.equal(contact.extra.opt_out_reason, '');

--- a/test/personal.test.js
+++ b/test/personal.test.js
@@ -161,9 +161,11 @@ describe("app", function() {
             describe("when the last state is states_start", function() {
                 it("should not fire no_incomplete", function() {
                     return tester
-                        .setup.user.lang('en')
-                        .start()
-                        .input.session_event('close')
+                        .inputs(
+                            {session_event: 'new'}  // states_start
+                            , {session_event: 'close'}  // states_start
+                        )
+                        // check metrics
                         .check(function(api) {
                             var metrics = api.metrics.stores.test_metric_store;
                             assert.equal(metrics['test.personal.states_start.no_incomplete'], undefined);
@@ -176,7 +178,10 @@ describe("app", function() {
                 it("should not fire no_incomplete", function() {
                     return tester
                         .setup.user.state('states_faq_topics')
-                        .input.session_event('close')
+                        .inputs(
+                            {session_event: 'close'}
+                        )
+                        // check metrics
                         .check(function(api) {
                             var metrics = api.metrics.stores.test_metric_store;
                             assert.equal(metrics['test.personal.states_faq_topics.no_incomplete'], undefined);
@@ -189,7 +194,10 @@ describe("app", function() {
                 it("should increase states_language.no_incomplete metric by 1", function() {
                     return tester
                         .setup.user.state('states_language')
-                        .input.session_event('close')
+                        .inputs(
+                            {session_event: 'close'}
+                        )
+                        // check metrics
                         .check(function(api) {
                             var metrics = api.metrics.stores.test_metric_store;
                             assert.deepEqual(metrics['test.personal.states_language.no_incomplete'].values, [1]);
@@ -202,7 +210,10 @@ describe("app", function() {
                 it("should increase states_birth_day.no_incomplete metric by 1", function() {
                     return tester
                         .setup.user.state('states_birth_day')
-                        .input.session_event('close')
+                        .inputs(
+                            {session_event: 'close'}
+                        )
+                        // check metrics
                         .check(function(api) {
                             var metrics = api.metrics.stores.test_metric_store;
                             assert.deepEqual(metrics['test.personal.states_birth_day.no_incomplete'].values, [1]);
@@ -217,25 +228,16 @@ describe("app", function() {
                         .setup(function(api) {
                             api.contacts.add({
                                 msisdn: '+27001',
-                                extra : {
-                                    language_choice: 'en',
-                                    suspect_pregnancy: 'yes',
-                                    id_type: 'passport',
-                                    passport_origin: 'zw',
-                                    passport_no: '12345',
-                                    ussd_sessions: '5'
-                                },
                                 key: "63ee4fa9-6888-4f0c-065a-939dc2473a99",
                                 user_account: "4a11907a-4cc4-415a-9011-58251e15e2b4"
                             });
                         })
                         .setup.user.addr('27001')
-                        .setup.user.answers({
-                            'states_birth_year': '1981',
-                            'states_birth_month': '01'
-                        })
                         .setup.user.state('states_end_success')
-                        .input.session_event('close')
+                        .inputs(
+                            {session_event: 'close'}
+                        )
+                        // check metrics
                         .check(function(api) {
                             var metrics = api.metrics.stores.test_metric_store;
                             assert.deepEqual(metrics['test.personal.states_end_success.no_incomplete'], undefined);
@@ -251,7 +253,10 @@ describe("app", function() {
                 it("should not fire no_incomplete", function() {
                     return tester
                         .setup.user.addr('275678')
-                        .start()
+                        .inputs(
+                            {session_event: 'new'}
+                        )
+                        // check metrics
                         .check(function(api) {
                             var metrics = api.metrics.stores.test_metric_store;
                             assert.equal(metrics['test.personal.states_start.no_incomplete'], undefined);
@@ -264,7 +269,10 @@ describe("app", function() {
                 it("should not fire no_incomplete", function() {
                     return tester
                         .setup.user.lang('en')  // make sure user is not seen as new
-                        .start()
+                        .inputs(
+                            {session_event: 'new'}
+                        )
+                        // check metrics
                         .check(function(api) {
                             var metrics = api.metrics.stores.test_metric_store;
                             assert.equal(metrics['test.personal.states_start.no_incomplete'], undefined);
@@ -276,6 +284,7 @@ describe("app", function() {
             describe("when it is an existing starting a session at states_birth_day", function() {
                 it("should decrease the metric states_birth_day.no_incomplete by 1", function() {
                     return tester
+                        .setup.user.lang('en')  // make sure user is not seen as new
                         .setup.user.state('states_birth_day')
                         .check(function(api) {
                             var metrics = api.metrics.stores.test_metric_store;

--- a/test/personal.test.js
+++ b/test/personal.test.js
@@ -2149,13 +2149,16 @@ describe("app", function() {
                 });
         });
 
-        describe("when the user starts a session (no prior timeout)", function() {
+        describe("when the user has no previous registration", function() {
 
-            describe("when the user has not started registration", function() {
+            describe("when they start a new session", function() {
                 it("should ask for their preferred language", function() {
                     return tester
                         .setup.user.addr('27001')
-                        .start()
+                        .inputs(
+                            {session_event: 'new'}  // states_start
+                        )
+                        // check navigation
                         .check.interaction({
                             state: 'states_language',
                             reply: [
@@ -2168,12 +2171,14 @@ describe("app", function() {
                                 '6. Setswana'
                             ].join('\n')
                         })
+                        // check extras
                         .check(function(api) {
                             var contact = api.contacts.store[0];
                             assert.equal(contact.extra.ussd_sessions, '1');
                             assert.equal(contact.extra.metric_sum_sessions, '1');
                             assert.equal(contact.extra.last_stage, 'states_language');
                         })
+                        // check metrics
                         .check(function(api) {
                             var metrics = api.metrics.stores.test_metric_store;
                             assert.deepEqual(metrics['test.sum.sessions'].values, [1]);
@@ -2182,13 +2187,15 @@ describe("app", function() {
                 });
             });
 
-
             describe("when the user selects english as language", function() {
                 it("should ask if they suspect pregnancy", function() {
                     return tester
                         .setup.user.addr('27001')
-                        .setup.user.state('states_language')
-                        .input('1')
+                        .inputs(
+                            {session_event: 'new'}  // states_start
+                            , '1'  // states_language
+                        )
+                        // check navigation
                         .check.interaction({
                             state: 'states_suspect_pregnancy',
                             reply: [
@@ -2207,74 +2214,75 @@ describe("app", function() {
                 it("should set pregnancy status, state service is for pregnant moms, exit", function() {
                     return tester
                         .setup.user.addr('27001')
-                        .setup.user.state('states_suspect_pregnancy')
-                        .input('2')
+                        .inputs(
+                            {session_event: 'new'}  // states_start
+                            , '1'  // states_language
+                            , '2'  // states_suspect_pregnancy
+                        )
+                        // check navigation
                         .check.interaction({
                             state: 'states_end_not_pregnant',
                             reply: ('We are sorry but this service is only for ' +
                                 'pregnant mothers. If you have other health ' +
                                 'concerns please visit your nearest clinic.')
                         })
-                        .check.reply.ends_session()
+                        // check extras
                         .check(function(api) {
                             var contact = api.contacts.store[0];
                             assert.equal(contact.extra.suspect_pregnancy, 'no');
                         })
+                        // check session ends
+                        .check.reply.ends_session()
                         .run();
                 });
             });
 
-            describe("after the confirms pregnant", function() {
+            describe("after the confirms pregnancy", function() {
                 it("should save their data, thank them and exit", function() {
                     return tester
                         .setup(function(api) {
                             api.contacts.add({
                                 msisdn: '+27001',
-                                extra : {
-                                    language_choice: 'en',
-                                    suspect_pregnancy: 'yes',
-                                    ussd_sessions: '1'
-                                },
                                 key: "63ee4fa9-6888-4f0c-065a-939dc2473a99",
                                 user_account: "4a11907a-4cc4-415a-9011-58251e15e2b4"
                             });
                         })
                         .setup.user.addr('27001')
-                        .setup.user.state('states_suspect_pregnancy')
-                        .input('1')
+                        .inputs(
+                            {session_event: 'new'}  // states_start
+                            , '1'  // states_language
+                            , '1'  // states_suspect_pregnancy
+                        )
+                        // check navigation
                         .check.interaction({
                             state: 'states_end_success',
                             reply: ('Congratulations on your pregnancy. You will now get free SMSs about MomConnect. You can register for the full set of FREE helpful messages at a clinic.')
                         })
+                        // check extras
                         .check(function(api) {
                             var contact = api.contacts.store[0];
                             assert.equal(contact.extra.language_choice, 'en');
                         })
+                        // check session ends
                         .check.reply.ends_session()
                         .run();
                 });
             });
-            describe("redialing after timeout", function() {
-                it("ask if want to continue", function() {
+
+            describe("if the user redials after timeout", function() {
+                it("should ask if they want to continue", function() {
                     return tester
                         .setup(function(api) {
                             api.contacts.add({
-                                msisdn: '+27001',
-                                extra : {},
-                                key: "63ee4fa9-6888-4f0c-065a-939dc2473a99",
-                                user_account: "4a11907a-4cc4-415a-9011-58251e15e2b4"
+                                msisdn: '+27001'
                             });
                         })
                         .setup.user.addr("27001")
-                        .setup.user.lang(null)
-                        .setup.user.answers({})
-                        .setup.user.metadata({
-                            session_length_helper: {
-                                start:1415791076582
-                            }
-                        })
-                        .setup.user.state('states_language')
-                        .inputs({session_event: 'new'})
+                        .inputs(
+                            {session_event: 'new'}  // states_start
+                            , {session_event: 'new'}  // simulate timeout and redial
+                        )
+                        // check navigation
                         .check.interaction({
                             state: 'states_timed_out',
                             reply: [
@@ -2286,27 +2294,23 @@ describe("app", function() {
                         .run();
                 });
             });
-            describe("redialing after timeout on timeout", function() {
-                it("ask if want to continue", function() {
+
+            describe("if the user redials after timing out on timeout state", function() {
+                it("should ask if they want to continue", function() {
                     return tester
                         .setup(function(api) {
                             api.contacts.add({
-                                msisdn: '+27001',
-                                extra : {},
-                                key: "63ee4fa9-6888-4f0c-065a-939dc2473a99",
-                                user_account: "4a11907a-4cc4-415a-9011-58251e15e2b4"
+                                msisdn: '+27001'
                             });
                         })
                         .setup.user.addr("27001")
-                        .setup.user.lang(null)
-                        .setup.user.answers({})
-                        .setup.user.metadata({
-                            session_length_helper: {
-                                start:1415791076582
-                            }
-                        })
-                        .setup.user.state("states_timed_out")
-                        .inputs({session_event: 'new'})
+                        .inputs(
+                            {session_event: 'new'}  // states_start
+                            , '1'  // states_language
+                            , {session_event: 'new'}  // simulate timeout and redial
+                            , {session_event: 'new'}  // simulate timeout and redial
+                        )
+                        // check navigation
                         .check.interaction({
                             state: 'states_timed_out',
                             reply: [
@@ -2320,13 +2324,13 @@ describe("app", function() {
             });
         });
 
-        describe("when the user has registered on clinic", function() {
+        describe("when the user has previously registered on clinic", function() {
             describe("when the user has active subscriptions", function() {
-                it("should prompt for info / compliment / complaint", function() {
+                it("should prompt for compliment / complaint in their language", function() {
                     return tester
                         .setup(function(api) {
                             api.contacts.add({
-                                msisdn: '+27001',
+                                msisdn: '+27821234444',
                                 extra : {
                                     language_choice: 'xh',
                                     is_registered: 'true',
@@ -2334,8 +2338,11 @@ describe("app", function() {
                                 },
                             });
                         })
-                        .setup.user.addr('27001')
-                        .start()
+                        .setup.user.addr('27821234444')
+                        .inputs(
+                            {session_event: 'new'}  // states_start
+                        )
+                        // check navigation
                         .check.interaction({
                             state: 'states_registered_full',
                             reply: [
@@ -2345,13 +2352,58 @@ describe("app", function() {
                                 '2. Send us a complaint'
                             ].join('\n')
                         })
+                        // check language gets set
                         .check.user.properties({lang: 'xh'})
+                        .run();
+                });
+
+                it("should send help them with complaint submission if they so choose", function() {
+                    return tester
+                        .setup(function(api) {
+                            api.contacts.add({
+                                msisdn: '+27821234444',
+                                extra : {
+                                    language_choice: 'xh',
+                                    is_registered: 'true',
+                                    is_registered_by: 'clinic'
+                                },
+                            });
+                        })
+                        .setup.user.addr('27821234444')
+                        .inputs(
+                            {session_event: 'new'}  // states_start
+                            , '2'  // states_registered_full
+                        )
+                        // check navigation
+                        .check.interaction({
+                            state: 'states_end_complaint',
+                            reply: [
+                                'Thank you. We will send you a message ' +
+                                'shortly with instructions on how to send us ' +
+                                'your complaint.'
+                            ].join('\n')
+                        })
+                        // check sms is sent
+                        .check(function(api) {
+                            var smses = _.where(api.outbound.store, {
+                                endpoint: 'sms'
+                            });
+                            var sms = smses[0];
+                            assert.equal(smses.length, 1);
+                            assert.equal(sms.content,
+                                "Please reply to this message with your complaint. If it " +
+                                "relates to the service at the clinic, include the clinic or " +
+                                "clinic worker name. Standard rates apply."
+                            );
+                        })
+                        // check session ends
+                        .check.reply.ends_session()
                         .run();
                 });
             });
 
             describe("when the user has no active subscriptions", function() {
-                it("should ask if they want to register or get info", function() {
+                it("should ask in their language if they want to register or get info", function() {
                     return tester
                         .setup(function(api) {
                             api.contacts.add({
@@ -2364,7 +2416,10 @@ describe("app", function() {
                             });
                         })
                         .setup.user.addr('27821235555')
-                        .start()
+                        .inputs(
+                            {session_event: 'new'}  // states_start
+                        )
+                        // check navigation
                         .check.interaction({
                             state: 'states_suspect_pregnancy',
                             reply: [
@@ -2375,9 +2430,126 @@ describe("app", function() {
                                 '2. No'
                             ].join('\n')
                         })
+                        // check language gets set
                         .check.user.properties({lang: 'xh'})
                         .run();
                 });
+            });
+        });
+
+        describe("when the user has previously registered on chw", function() {
+            it("should provide choice for getting full messages in their language", function() {
+                return tester
+                    .setup(function(api) {
+                        api.contacts.add({
+                            msisdn: '+27001',
+                            extra : {
+                                language_choice: 'xh',
+                                is_registered: 'true',
+                                is_registered_by: 'chw'
+                            },
+                        });
+                    })
+                    .setup.user.addr('27001')
+                    .inputs(
+                        {session_event: 'new'}  // states_start
+                    )
+                    // check navigation
+                    .check.interaction({
+                        state: 'states_registered_not_full',
+                        reply: [
+                            'Welcome to the Department of Health\'s ' +
+                            'MomConnect. Choose an option:',
+                            '1. Get the full set of messages'
+                        ].join('\n')
+                    })
+                    // check language gets set
+                    .check.user.properties({lang: 'xh'})
+                    .run();
+            });
+
+            it("should tell them to go to the clinic if they want full msgs", function() {
+                return tester
+                    .setup(function(api) {
+                        api.contacts.add({
+                            msisdn: '+27001',
+                            extra : {
+                                is_registered: 'true',
+                                is_registered_by: 'chw'
+                            },
+                        });
+                    })
+                    .setup.user.addr('27001')
+                    .inputs(
+                        {session_event: 'new'}  // states_start
+                        , '1'  // states_registerd_not_full
+                    )
+                    .check.interaction({
+                        state: 'states_end_go_clinic',
+                        reply: [
+                            'To register for the full set of MomConnect ' +
+                            'messages, please visit your nearest clinic.'
+                        ].join('\n')
+                    })
+                    .run();
+            });
+        });
+
+        describe("when the user has previously registered on public", function() {
+            it("should provide choice for getting full messages in their language", function() {
+                return tester
+                    .setup(function(api) {
+                        api.contacts.add({
+                            msisdn: '+27001',
+                            extra : {
+                                language_choice: 'xh',
+                                is_registered: 'true',
+                                is_registered_by: 'personal'
+                            },
+                        });
+                    })
+                    .setup.user.addr('27001')
+                    .inputs(
+                        {session_event: 'new'}  // states_start
+                    )
+                    // check navigation
+                    .check.interaction({
+                        state: 'states_registered_not_full',
+                        reply: [
+                            'Welcome to the Department of Health\'s ' +
+                            'MomConnect. Choose an option:',
+                            '1. Get the full set of messages'
+                        ].join('\n')
+                    })
+                    // check language gets set
+                    .check.user.properties({lang: 'xh'})
+                    .run();
+            });
+
+            it("should tell them to go to the clinic if they want full msgs", function() {
+                return tester
+                    .setup(function(api) {
+                        api.contacts.add({
+                            msisdn: '+27001',
+                            extra : {
+                                is_registered: 'true',
+                                is_registered_by: 'personal'
+                            },
+                        });
+                    })
+                    .setup.user.addr('27001')
+                    .inputs(
+                        {session_event: 'new'}  // states_start
+                        , '1'  // states_registerd_not_full
+                    )
+                    .check.interaction({
+                        state: 'states_end_go_clinic',
+                        reply: [
+                            'To register for the full set of MomConnect ' +
+                            'messages, please visit your nearest clinic.'
+                        ].join('\n')
+                    })
+                    .run();
             });
         });
     });

--- a/test/personal.test.js
+++ b/test/personal.test.js
@@ -1882,7 +1882,7 @@ describe("app", function() {
                     .inputs('3', '1', '1', '1')
                     .check.interaction({
                         state: 'states_faq_answers',
-                        reply: ['want to test properly. Let\'s see.',
+                        reply: ['to test properly. Let\'s see.',
                             '1. Back',
                             '2. Send to me by SMS'
                         ].join('\n')

--- a/test/servicerating.test.js
+++ b/test/servicerating.test.js
@@ -180,7 +180,7 @@ describe("app", function() {
                                 msisdn: '+27001',
                             });
                         })
-                        .start()
+                        .inputs({session_event: 'new'})
                         .check.interaction({
                             state: 'end_reg_clinic',
                             reply: 'Please register at a clinic before using this line.'
@@ -203,7 +203,7 @@ describe("app", function() {
                                 }
                             });
                         })
-                        .start()
+                        .inputs({session_event: 'new'})
                         .check.interaction({
                             state: 'question_1_friendliness',
                             reply: [
@@ -233,7 +233,7 @@ describe("app", function() {
                                 }
                             });
                         })
-                        .start()
+                        .inputs({session_event: 'new'})
                         .check.interaction({
                             state: 'end_thanks_revisit',
                             reply: [
@@ -251,9 +251,17 @@ describe("app", function() {
         describe("when the user answers their friendliness rating", function() {
             it("should ask for their waiting times feeling", function() {
                 return tester
+                    .setup(function(api) {
+                        api.contacts.add({
+                            msisdn: '+27001',
+                            extra : {
+                                is_registered_by: 'clinic',
+                                last_service_rating: 'never'
+                            }
+                        });
+                    })
                     .setup.user.addr('27001')
-                    .setup.user.state('question_1_friendliness')
-                    .input('1')
+                    .inputs({session_event: 'new'}, '1')
                     .check.interaction({
                         state: 'question_2_waiting_times_feel',
                         reply: [
@@ -271,9 +279,17 @@ describe("app", function() {
         describe("when the user answers their waiting times feeling", function() {
             it("should ask for their waiting times length feeling", function() {
                 return tester
+                    .setup(function(api) {
+                        api.contacts.add({
+                            msisdn: '+27001',
+                            extra : {
+                                is_registered_by: 'clinic',
+                                last_service_rating: 'never'
+                            }
+                        });
+                    })
                     .setup.user.addr('27001')
-                    .setup.user.state('question_2_waiting_times_feel')
-                    .input('1')
+                    .inputs({session_event: 'new'}, '1', '1')
                     .check.interaction({
                         state: 'question_3_waiting_times_length',
                         reply: [
@@ -291,9 +307,17 @@ describe("app", function() {
         describe("when the user answers their waiting times length feeling", function() {
             it("should ask for their cleanliness rating", function() {
                 return tester
+                    .setup(function(api) {
+                        api.contacts.add({
+                            msisdn: '+27001',
+                            extra : {
+                                is_registered_by: 'clinic',
+                                last_service_rating: 'never'
+                            }
+                        });
+                    })
                     .setup.user.addr('27001')
-                    .setup.user.state('question_3_waiting_times_length')
-                    .input('1')
+                    .inputs({session_event: 'new'}, '1', '1', '1')
                     .check.interaction({
                         state: 'question_4_cleanliness',
                         reply: [
@@ -311,9 +335,17 @@ describe("app", function() {
         describe("when the user answers their cleanliness rating", function() {
             it("should ask for their privacy rating", function() {
                 return tester
+                    .setup(function(api) {
+                        api.contacts.add({
+                            msisdn: '+27001',
+                            extra : {
+                                is_registered_by: 'clinic',
+                                last_service_rating: 'never'
+                            }
+                        });
+                    })
                     .setup.user.addr('27001')
-                    .setup.user.state('question_4_cleanliness')
-                    .input('1')
+                    .inputs({session_event: 'new'}, '1', '1', '1', '1')
                     .check.interaction({
                         state: 'question_5_privacy',
                         reply: [
@@ -337,22 +369,15 @@ describe("app", function() {
                             created_at: "2014-07-28 09:35:26.732",
                             key: "63ee4fa9-6888-4f0c-065a-939dc2473a99",
                             user_account: "4a11907a-4cc4-415a-9011-58251e15e2b4",
-                            extra: {
-                                is_registered_by: "clinic",
-                                clinic_code: "12345",
-                                last_service_rating: "never"
+                            extra : {
+                                is_registered_by: 'clinic',
+                                clinic_code: '12345',
+                                last_service_rating: 'never'
                             }
                         });
                     })
                     .setup.user.addr('27001')
-                    .setup.user.state('question_5_privacy')
-                    .setup.user.answers({
-                        'question_1_friendliness': 'very-satisfied',
-                        'question_2_waiting_times_feel': 'very-satisfied',
-                        'question_3_waiting_times_length': 'less-than-an-hour',
-                        'question_4_cleanliness': 'very-satisfied'
-                    })
-                    .input('1')
+                    .inputs({session_event: 'new'}, '1', '1', '1', '1', '1')
                     .check.interaction({
                         state: 'end_thanks',
                         reply: [

--- a/test/servicerating.test.js
+++ b/test/servicerating.test.js
@@ -387,79 +387,33 @@ describe("app", function() {
                     .check.reply.ends_session()
                     .run();
             });
-        });
 
-        describe("when the user revisits after rating service previously", function() {
-            it("should thank and end", function() {
+            it("save the servicerating date to their contact extras", function() {
                 return tester
                     .setup(function(api) {
                         api.contacts.add({
                             msisdn: '+27001',
                             created_at: "2014-07-28 09:35:26.732",
                             key: "63ee4fa9-6888-4f0c-065a-939dc2473a99",
-                            user_account: "4a11907a-4cc4-415a-9011-58251e15e2b4"
+                            user_account: "4a11907a-4cc4-415a-9011-58251e15e2b4",
+                            extra : {
+                                is_registered_by: 'clinic',
+                                clinic_code: '12345',
+                                last_service_rating: 'never'
+                            }
                         });
                     })
                     .setup.user.addr('27001')
-                    .setup.user.answers({
-                        'question_1_friendliness': 'very-satisfied',
-                        'question_2_waiting_times_feel': 'very-satisfied',
-                        'question_3_waiting_times_length': 'less-than-an-hour',
-                        'question_4_cleanliness': 'very-satisfied',
-                        'question_5_privacy': 'very-satisfied'
-                    })
-                    .setup.user.state('end_thanks')
-                    .check.interaction({
-                        state: 'end_thanks_revisit',
-                        reply: [
-                            'Sorry, you\'ve already rated service. For baby and pregnancy ' +
-                            'help or if you have compliments or complaints ' +
-                            'dial *120*550# or reply to any of the SMSs you receive'
-                        ].join('\n')
-                    })
-                    .check.reply.ends_session()
-                    .run();
-            });
-
-            it("should not send another sms", function() {
-                return tester
-                    .setup(function(api) {
-                        api.contacts.add({
-                            msisdn: '+27001',
-                            created_at: "2014-07-28 09:35:26.732",
-                            key: "63ee4fa9-6888-4f0c-065a-939dc2473a99",
-                            user_account: "4a11907a-4cc4-415a-9011-58251e15e2b4"
-                        });
-                    })
-                    .setup.user.addr('27001')
-                    .setup.user.answers({
-                        'question_1_friendliness': 'very-satisfied',
-                        'question_2_waiting_times_feel': 'very-satisfied',
-                        'question_3_waiting_times_length': 'less-than-an-hour',
-                        'question_4_cleanliness': 'very-satisfied',
-                        'question_5_privacy': 'very-satisfied'
-                    })
-                    .setup.user.state('end_thanks')
-                    .check.interaction({
-                        state: 'end_thanks_revisit',
-                        reply: [
-                            'Sorry, you\'ve already rated service. For baby and pregnancy ' +
-                            'help or if you have compliments or complaints ' +
-                            'dial *120*550# or reply to any of the SMSs you receive'
-                        ].join('\n')
-                    })
+                    .inputs({session_event: 'new'}, '1', '1', '1', '1', '1')
                     .check(function(api) {
-                        var smses = _.where(api.outbound.store, {
-                            endpoint: 'sms'
+                        var contact = _.find(api.contacts.store, {
+                          msisdn: '+27001'
                         });
-                        assert.equal(smses.length, 0);
+                        assert.equal(contact.extra.last_service_rating, '20130819144811');
                     })
-                    .check.reply.ends_session()
                     .run();
             });
-        });
 
-        describe("when the user answers their privacy rating", function() {
             it("should send them an sms thanking them for their rating", function() {
                 return tester
                     .setup(function(api) {
@@ -468,22 +422,15 @@ describe("app", function() {
                             created_at: "2014-07-28 09:35:26.732",
                             key: "63ee4fa9-6888-4f0c-065a-939dc2473a99",
                             user_account: "4a11907a-4cc4-415a-9011-58251e15e2b4",
-                            extra: {
-                                is_registered_by: "clinic",
-                                clinic_code: "12345",
+                            extra : {
+                                is_registered_by: 'clinic',
+                                clinic_code: '12345',
                                 last_service_rating: 'never'
                             }
                         });
                     })
                     .setup.user.addr('27001')
-                    .setup.user.state('question_5_privacy')
-                    .setup.user.answers({
-                        'question_1_friendliness': 'very-satisfied',
-                        'question_2_waiting_times_feel': 'very-satisfied',
-                        'question_3_waiting_times_length': 'less-than-an-hour',
-                        'question_4_cleanliness': 'very-satisfied'
-                    })
-                    .input('1')
+                    .inputs({session_event: 'new'}, '1', '1', '1', '1', '1')
                     .check(function(api) {
                         var smses = _.where(api.outbound.store, {
                             endpoint: 'sms'
@@ -495,13 +442,6 @@ describe("app", function() {
                         );
                         assert.equal(sms.to_addr,'27001');
                     })
-                    .check(function(api) {
-                            var contact = _.find(api.contacts.store, {
-                              msisdn: '+27001'
-                            });
-                            assert.equal(contact.extra.last_service_rating, '20130819144811');
-                        })
-                    .check.reply.ends_session()
                     .run();
             });
 
@@ -541,6 +481,71 @@ describe("app", function() {
                     })
                     .run();
             });
+
         });
+
+        describe("when the user revisits after rating service previously", function() {
+            it("should not allow them to rate again", function() {
+                return tester
+                    .setup(function(api) {
+                        api.contacts.add({
+                            msisdn: '+27001',
+                            created_at: "2014-07-28 09:35:26.732",
+                            key: "63ee4fa9-6888-4f0c-065a-939dc2473a99",
+                            user_account: "4a11907a-4cc4-415a-9011-58251e15e2b4",
+                            extra : {
+                                is_registered_by: 'clinic',
+                                clinic_code: '12345',
+                                last_service_rating: 'never'
+                            }
+                        });
+                    })
+                    .setup.user.addr('27001')
+                    .inputs({session_event: 'new'}, '1', '1', '1', '1', '1', {session_event: 'new'})
+                    .check.interaction({
+                        state: 'end_thanks_revisit',
+                        reply: [
+                            'Sorry, you\'ve already rated service. For baby and pregnancy ' +
+                            'help or if you have compliments or complaints ' +
+                            'dial *120*550# or reply to any of the SMSs you receive'
+                        ].join('\n')
+                    })
+                    .check.reply.ends_session()
+                    .run();
+            });
+
+            it("should not send another sms", function() {
+                return tester
+                    .setup(function(api) {
+                        api.contacts.add({
+                            msisdn: '+27001',
+                            extra : {
+                                is_registered_by: 'clinic',
+                                clinic_code: '12345',
+                                last_service_rating: 'any-string-except-"never"-or-undefined'
+                            }
+                        });
+                    })
+                    .setup.user.addr('27001')
+                    .inputs({session_event: 'new'})
+                    .check.interaction({
+                        state: 'end_thanks_revisit',
+                        reply: [
+                            'Sorry, you\'ve already rated service. For baby and pregnancy ' +
+                            'help or if you have compliments or complaints ' +
+                            'dial *120*550# or reply to any of the SMSs you receive'
+                        ].join('\n')
+                    })
+                    .check(function(api) {
+                        var smses = _.where(api.outbound.store, {
+                            endpoint: 'sms'
+                        });
+                        assert.equal(smses.length, 0);
+                    })
+                    .check.reply.ends_session()
+                    .run();
+            });
+        });
+
     });
 });

--- a/test/smsinbound.test.js
+++ b/test/smsinbound.test.js
@@ -171,7 +171,7 @@ describe("app", function() {
                                 user_account: "4a11907a-4cc4-415a-9011-58251e15e2b4"
                             });
                         })
-                        .input('start')
+                        .inputs('start')
                         .check(function(api) {
                             var metrics = api.metrics.stores.test_metric_store;
                             assert.deepEqual(metrics['test.smsinbound.sum.unique_users'].values, [1]);
@@ -224,7 +224,7 @@ describe("app", function() {
                             });
                         })
                         .setup.user.addr('27001')
-                        .input('STOP')
+                        .inputs('STOP')
                         .check(function(api) {
                             var metrics = api.metrics.stores.test_metric_store;
                             // should NOT inc total subscriptions metric
@@ -284,7 +284,7 @@ describe("app", function() {
                             testing_today: 'April 4, 2014 09:07:07 GMT+0200 (SAST)'
                         })
                         .setup.user.addr('27001')
-                        .input('DONUTS')
+                        .inputs('DONUTS')
                         .check.interaction({
                             state: 'states_default',
                             reply:
@@ -313,7 +313,7 @@ describe("app", function() {
                             testing_today: 'April 4, 2014 07:07:07  GMT+0200 (SAST)'
                         })
                         .setup.user.addr('27001')
-                        .input('DONUTS')
+                        .inputs('DONUTS')
                         .check.interaction({
                             state: 'states_default',
                             reply:
@@ -343,7 +343,7 @@ describe("app", function() {
                             testing_today: 'April 5, 2014 09:07:07  GMT+0200 (SAST)'
                         })
                         .setup.user.addr('27001')
-                        .input('DONUTS')
+                        .inputs('DONUTS')
                         .check.interaction({
                             state: 'states_default',
                             reply:
@@ -373,7 +373,7 @@ describe("app", function() {
                             testing_today: 'August 10, 2015 09:07:07  GMT+0200 (SAST)'
                         })
                         .setup.user.addr('27001')
-                        .input('DONUTS')
+                        .inputs('DONUTS')
                         .check.interaction({
                             state: 'states_default',
                             reply:
@@ -401,7 +401,7 @@ describe("app", function() {
                         });
                     })
                     .setup.user.addr('27001')
-                    .input('*134*12345# rate')
+                    .inputs('*134*12345# rate')
                     .check.interaction({
                         state: 'states_dial_not_sms',
                         reply:
@@ -427,7 +427,7 @@ describe("app", function() {
                         });
                     })
                     .setup.user.addr('27001')
-                    .input('"stop" in the name of love')
+                    .inputs('"stop" in the name of love')
                     .check.interaction({
                         state: 'states_opt_out',
                         reply:
@@ -457,7 +457,7 @@ describe("app", function() {
                         });
                     })
                     .setup.user.addr('27001')
-                    .input('BLOCK')
+                    .inputs('BLOCK')
                     .check.interaction({
                         state: 'states_opt_out',
                         reply:
@@ -487,7 +487,7 @@ describe("app", function() {
                         });
                     })
                     .setup.user.addr('27001')
-                    .input('"START"')
+                    .inputs('"START"')
                     .check.interaction({
                         state: 'states_opt_in',
                         reply:
@@ -516,7 +516,7 @@ describe("app", function() {
                         });
                     })
                     .setup.user.addr('27001')
-                    .input('baBy has been born, bub')
+                    .inputs('baBy has been born, bub')
                     .check.interaction({
                         state: 'states_baby',
                         reply:


### PR DESCRIPTION
```
$ grunt mochaTest:test_smsinbound
Running "mochaTest:test_smsinbound" (mochaTest) task


  app
    for sms inbound use
      using the session length helper
        ✓ should publish metrics (86ms)
      when a new unique user sends message in
        ✓ should increment the no. of unique users by 1 (72ms)
      when the user sends a non standard keyword message
        ✓ should log a support ticket (76ms)
      when the user sends a message containing a USSD code
        ✓ should tell them to dial the number, not sms it (70ms)
      when the user sends a STOP message
        1) should set their opt out status
      when the user sends a BLOCK message
        2) should set their opt out status
      when the user sends a START message
        ✓ should reverse their opt out status (58ms)
      when the user sends a BABY message
        ✓ should switch their subscription to baby protocol (90ms)


  6 passing (596ms)
  2 failing

  1) app for sms inbound use when the user sends a STOP message should set their opt out status:
     ReferenceError: opts is not defined
      at /Users/sdehaan/Documents/Repositories/go-ndoh/src/smsinbound.js:79:90
      at _fulfilled (/Users/sdehaan/Documents/Repositories/go-ndoh/node_modules/q/q.js:798:54)
      at self.promiseDispatch.done (/Users/sdehaan/Documents/Repositories/go-ndoh/node_modules/q/q.js:827:30)
      at Promise.promise.promiseDispatch (/Users/sdehaan/Documents/Repositories/go-ndoh/node_modules/q/q.js:760:13)
      at /Users/sdehaan/Documents/Repositories/go-ndoh/node_modules/q/q.js:574:44
      at flush (/Users/sdehaan/Documents/Repositories/go-ndoh/node_modules/q/q.js:108:17)
      at process._tickDomainCallback (node.js:459:13)

  2) app for sms inbound use when the user sends a BLOCK message should set their opt out status:
     ReferenceError: opts is not defined
      at /Users/sdehaan/Documents/Repositories/go-ndoh/src/smsinbound.js:79:90
      at _fulfilled (/Users/sdehaan/Documents/Repositories/go-ndoh/node_modules/q/q.js:798:54)
      at self.promiseDispatch.done (/Users/sdehaan/Documents/Repositories/go-ndoh/node_modules/q/q.js:827:30)
      at Promise.promise.promiseDispatch (/Users/sdehaan/Documents/Repositories/go-ndoh/node_modules/q/q.js:760:13)
      at /Users/sdehaan/Documents/Repositories/go-ndoh/node_modules/q/q.js:574:44
      at flush (/Users/sdehaan/Documents/Repositories/go-ndoh/node_modules/q/q.js:108:17)
      at process._tickDomainCallback (node.js:459:13)



Warning: Task "mochaTest:test_smsinbound" failed. Use --force to continue.

Aborted due to warnings.
```

Which is correct because [`opts`](https://github.com/praekelt/go-ndoh/blob/develop/src/smsinbound.js#L77) is not defined anywhere, it's likely that your tests are leaking variables somewhere which means this bit of code manages to grab some `opts` value from somewhere.
