### PR TITLE
Use translation text for outbound CHW SMS

### DIFF
--- a/config/go-app-chw.pot
+++ b/config/go-app-chw.pot
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"POT-Creation-Date: 2015-09-23 09:01:+0000\n"
+"POT-Creation-Date: 2015-10-14 06:27:+0000\n"
 "Project-Id-Version: PACKAGE VERSION\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
@@ -57,196 +57,172 @@ msgstr ""
 msgid "Dec"
 msgstr ""
 
-#: go-app-chw.js:1222
+#: go-app-chw.js:1252
 msgid ""
 "Please dial back in to {{ USSD_number }} to complete the pregnancy "
 "registration."
 msgstr ""
 
-#: go-app-chw.js:1251
+#: go-app-chw.js:1281
 msgid "Would you like to complete pregnancy registration for {{ num }}?"
 msgstr ""
 
-#: go-app-chw.js:1256 go-app-chw.js:1287 go-app-chw.js:1315
+#: go-app-chw.js:1286 go-app-chw.js:1317 go-app-chw.js:1345
 msgid "Yes"
 msgstr ""
 
-#: go-app-chw.js:1257
+#: go-app-chw.js:1287
 msgid "Start new registration"
 msgstr ""
 
-#: go-app-chw.js:1281
+#: go-app-chw.js:1311
 msgid ""
 "Welcome to The Department of Health's MomConnect. Tell us if this is the "
 "no. that the mother would like to get SMSs on: {{ num }}"
 msgstr ""
 
-#: go-app-chw.js:1288 go-app-chw.js:1316
+#: go-app-chw.js:1318 go-app-chw.js:1346
 msgid "No"
 msgstr ""
 
-#: go-app-chw.js:1310
+#: go-app-chw.js:1340
 msgid ""
 "This number has previously opted out of MomConnect SMSs. Please confirm "
 "that the mom would like to opt in to receive messages again?"
 msgstr ""
 
-#: go-app-chw.js:1344
+#: go-app-chw.js:1374
 msgid ""
 "You have chosen not to receive MomConnect SMSs and so cannot complete "
 "registration."
 msgstr ""
 
-#: go-app-chw.js:1348
+#: go-app-chw.js:1378
 msgid "Main Menu"
 msgstr ""
 
-#: go-app-chw.js:1358
+#: go-app-chw.js:1388
 msgid "Sorry, the mobile number did not validate. Please reenter the mobile number:"
 msgstr ""
 
-#: go-app-chw.js:1361
+#: go-app-chw.js:1391
 msgid "Please input the mobile number of the pregnant woman to be registered:"
 msgstr ""
 
-#: go-app-chw.js:1395
+#: go-app-chw.js:1425
 msgid "What kind of identification does the pregnant mother have?"
 msgstr ""
 
-#: go-app-chw.js:1399
+#: go-app-chw.js:1429
 msgid "SA ID"
 msgstr ""
 
-#: go-app-chw.js:1400
+#: go-app-chw.js:1430
 msgid "Passport"
 msgstr ""
 
-#: go-app-chw.js:1401
+#: go-app-chw.js:1431
 msgid "None"
 msgstr ""
 
-#: go-app-chw.js:1433
+#: go-app-chw.js:1463
 msgid ""
 "Sorry, the mother's ID number did not validate. Please reenter the SA ID "
 "number:"
 msgstr ""
 
-#: go-app-chw.js:1436
+#: go-app-chw.js:1466
 msgid "Please enter the pregnant mother's SA ID number:"
 msgstr ""
 
-#: go-app-chw.js:1470
+#: go-app-chw.js:1500
 msgid "What is the country of origin of the passport?"
 msgstr ""
 
-#: go-app-chw.js:1473
+#: go-app-chw.js:1503
 msgid "Zimbabwe"
 msgstr ""
 
-#: go-app-chw.js:1474
+#: go-app-chw.js:1504
 msgid "Mozambique"
 msgstr ""
 
-#: go-app-chw.js:1475
+#: go-app-chw.js:1505
 msgid "Malawi"
 msgstr ""
 
-#: go-app-chw.js:1476
+#: go-app-chw.js:1506
 msgid "Nigeria"
 msgstr ""
 
-#: go-app-chw.js:1477
+#: go-app-chw.js:1507
 msgid "DRC"
 msgstr ""
 
-#: go-app-chw.js:1478
+#: go-app-chw.js:1508
 msgid "Somalia"
 msgstr ""
 
-#: go-app-chw.js:1479
+#: go-app-chw.js:1509
 msgid "Other"
 msgstr ""
 
-#: go-app-chw.js:1497
+#: go-app-chw.js:1527
 msgid ""
 "There was an error in your entry. Please carefully enter the passport "
 "number again."
 msgstr ""
 
-#: go-app-chw.js:1499
+#: go-app-chw.js:1529
 msgid "Please enter the pregnant mother's Passport number:"
 msgstr ""
 
-#: go-app-chw.js:1525
+#: go-app-chw.js:1555
 msgid ""
 "There was an error in your entry. Please carefully enter the mother's year "
 "of birth again (for example: 2001)"
 msgstr ""
 
-#: go-app-chw.js:1529
+#: go-app-chw.js:1559
 msgid "Please enter the year that the pregnant mother was born (for example: 1981)"
 msgstr ""
 
-#: go-app-chw.js:1559
+#: go-app-chw.js:1589
 msgid "Please enter the month that you were born."
 msgstr ""
 
-#: go-app-chw.js:1578
+#: go-app-chw.js:1608
 msgid ""
 "There was an error in your entry. Please carefully enter the mother's day "
 "of birth again (for example: 8)"
 msgstr ""
 
-#: go-app-chw.js:1582
+#: go-app-chw.js:1612
 msgid "Please enter the day that the mother was born (for example: 14)."
 msgstr ""
 
-#: go-app-chw.js:1622
+#: go-app-chw.js:1652
 msgid "The date you entered ({{ dob }}) is not a real date. Please try again."
 msgstr ""
 
-#: go-app-chw.js:1627
+#: go-app-chw.js:1657
 msgid "Continue"
 msgstr ""
 
-#: go-app-chw.js:1636
+#: go-app-chw.js:1666
 msgid ""
 "Please select the language that the pregnant mother would like to get "
 "messages in:"
 msgstr ""
 
-#: go-app-chw.js:1640
-msgid "English"
-msgstr ""
-
-#: go-app-chw.js:1641
-msgid "Afrikaans"
-msgstr ""
-
-#: go-app-chw.js:1642
-msgid "Zulu"
-msgstr ""
-
-#: go-app-chw.js:1643
-msgid "Xhosa"
-msgstr ""
-
-#: go-app-chw.js:1644
-msgid "Sotho"
-msgstr ""
-
-#: go-app-chw.js:1645
-msgid "Setswana"
-msgstr ""
-
-#: go-app-chw.js:1697
+#: go-app-chw.js:1727
 msgid ""
 "Congratulations on your pregnancy. You will now get free SMSs about "
 "MomConnect. You can register for the full set of FREE helpful messages at a "
 "clinic."
 msgstr ""
 
-#: go-app-chw.js:1709
+#: go-app-chw.js:1739
 msgid ""
 "Thank you, registration is complete. The pregnant woman will now receive "
 "messages to encourage her to register at her nearest clinic."


### PR DESCRIPTION
When the CHW chooses none en for mother pref it should use that as the lang for confirmation test. As per: https://praekelt.atlassian.net/browse/NDOH-293
