### PR TITLE
Prevent active registration overrides

### DIFF
--- a/go-app-chw.js
+++ b/go-app-chw.js
@@ -711,7 +711,7 @@ go.utils = {
         });
     },
 
-    get_subscription_by_msisdn: function(msisdn, im) {
+    get_subscriptions_by_msisdn: function(msisdn, im) {
         var params = {
             to_addr: msisdn
         };
@@ -724,7 +724,7 @@ go.utils = {
 
     subscription_unsubscribe_all: function(contact, im) {
         return go.utils
-            .get_subscription_by_msisdn(contact.msisdn, im)
+            .get_subscriptions_by_msisdn(contact.msisdn, im)
             .then(function(update) {
                 var clean = true;  // clean tracks if api call is unnecessary
                 for (i=0;i<update.objects.length;i++) {

--- a/go-app-clinic.js
+++ b/go-app-clinic.js
@@ -711,7 +711,7 @@ go.utils = {
         });
     },
 
-    get_subscription_by_msisdn: function(msisdn, im) {
+    get_subscriptions_by_msisdn: function(msisdn, im) {
         var params = {
             to_addr: msisdn
         };
@@ -724,7 +724,7 @@ go.utils = {
 
     subscription_unsubscribe_all: function(contact, im) {
         return go.utils
-            .get_subscription_by_msisdn(contact.msisdn, im)
+            .get_subscriptions_by_msisdn(contact.msisdn, im)
             .then(function(update) {
                 var clean = true;  // clean tracks if api call is unnecessary
                 for (i=0;i<update.objects.length;i++) {

--- a/go-app-nurse_sms.js
+++ b/go-app-nurse_sms.js
@@ -711,7 +711,7 @@ go.utils = {
         });
     },
 
-    get_subscription_by_msisdn: function(msisdn, im) {
+    get_subscriptions_by_msisdn: function(msisdn, im) {
         var params = {
             to_addr: msisdn
         };
@@ -724,7 +724,7 @@ go.utils = {
 
     subscription_unsubscribe_all: function(contact, im) {
         return go.utils
-            .get_subscription_by_msisdn(contact.msisdn, im)
+            .get_subscriptions_by_msisdn(contact.msisdn, im)
             .then(function(update) {
                 var clean = true;  // clean tracks if api call is unnecessary
                 for (i=0;i<update.objects.length;i++) {

--- a/go-app-optout.js
+++ b/go-app-optout.js
@@ -711,7 +711,7 @@ go.utils = {
         });
     },
 
-    get_subscription_by_msisdn: function(msisdn, im) {
+    get_subscriptions_by_msisdn: function(msisdn, im) {
         var params = {
             to_addr: msisdn
         };
@@ -724,7 +724,7 @@ go.utils = {
 
     subscription_unsubscribe_all: function(contact, im) {
         return go.utils
-            .get_subscription_by_msisdn(contact.msisdn, im)
+            .get_subscriptions_by_msisdn(contact.msisdn, im)
             .then(function(update) {
                 var clean = true;  // clean tracks if api call is unnecessary
                 for (i=0;i<update.objects.length;i++) {

--- a/go-app-personal.js
+++ b/go-app-personal.js
@@ -711,7 +711,7 @@ go.utils = {
         });
     },
 
-    get_subscription_by_msisdn: function(msisdn, im) {
+    get_subscriptions_by_msisdn: function(msisdn, im) {
         var params = {
             to_addr: msisdn
         };
@@ -724,7 +724,7 @@ go.utils = {
 
     subscription_unsubscribe_all: function(contact, im) {
         return go.utils
-            .get_subscription_by_msisdn(contact.msisdn, im)
+            .get_subscriptions_by_msisdn(contact.msisdn, im)
             .then(function(update) {
                 var clean = true;  // clean tracks if api call is unnecessary
                 for (i=0;i<update.objects.length;i++) {

--- a/go-app-servicerating.js
+++ b/go-app-servicerating.js
@@ -711,7 +711,7 @@ go.utils = {
         });
     },
 
-    get_subscription_by_msisdn: function(msisdn, im) {
+    get_subscriptions_by_msisdn: function(msisdn, im) {
         var params = {
             to_addr: msisdn
         };
@@ -724,7 +724,7 @@ go.utils = {
 
     subscription_unsubscribe_all: function(contact, im) {
         return go.utils
-            .get_subscription_by_msisdn(contact.msisdn, im)
+            .get_subscriptions_by_msisdn(contact.msisdn, im)
             .then(function(update) {
                 var clean = true;  // clean tracks if api call is unnecessary
                 for (i=0;i<update.objects.length;i++) {

--- a/go-app-smsinbound.js
+++ b/go-app-smsinbound.js
@@ -711,7 +711,7 @@ go.utils = {
         });
     },
 
-    get_subscription_by_msisdn: function(msisdn, im) {
+    get_subscriptions_by_msisdn: function(msisdn, im) {
         var params = {
             to_addr: msisdn
         };
@@ -724,7 +724,7 @@ go.utils = {
 
     subscription_unsubscribe_all: function(contact, im) {
         return go.utils
-            .get_subscription_by_msisdn(contact.msisdn, im)
+            .get_subscriptions_by_msisdn(contact.msisdn, im)
             .then(function(update) {
                 var clean = true;  // clean tracks if api call is unnecessary
                 for (i=0;i<update.objects.length;i++) {

--- a/src/nurse_ussd.js
+++ b/src/nurse_ussd.js
@@ -319,9 +319,35 @@ go.app = function() {
                     if (opted_out === true) {
                         return self.states.create('st_opt_in_change');
                     } else {
-                        return self.states.create('isl_switch_new_nr');
+                        return self.states.create('isl_check_active_subs');
                     }
                 });
+        });
+
+        self.add('isl_check_active_subs', function(name) {
+            return go.utils
+                .get_subscriptions_by_msisdn(go.utils.normalize_msisdn(
+                    self.im.user.answers.st_change_num, '27'), self.im)
+                .then(function(subs) {
+                    var active_subs = 0;
+                    for (i=0; i<subs.objects.length; i++) {
+                        if (subs.objects[i].active === true) {
+                            active_subs += 1;
+                        }
+                    }
+                    if (active_subs === 0) {
+                        return self.states.create('isl_switch_new_nr');
+                    } else {
+                        return self.states.create('st_block_active_subs');
+                    }
+                });
+        });
+
+        self.add('st_block_active_subs', function(name) {
+            return new EndState(name, {
+                text: $("Sorry, the number you are trying to move to already has an active registration. To manage that registration, please redial from that number."),
+                next: 'isl_route',
+            });
         });
 
         self.add('isl_switch_new_nr', function(name) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -708,7 +708,7 @@ go.utils = {
         });
     },
 
-    get_subscription_by_msisdn: function(msisdn, im) {
+    get_subscriptions_by_msisdn: function(msisdn, im) {
         var params = {
             to_addr: msisdn
         };
@@ -721,7 +721,7 @@ go.utils = {
 
     subscription_unsubscribe_all: function(contact, im) {
         return go.utils
-            .get_subscription_by_msisdn(contact.msisdn, im)
+            .get_subscriptions_by_msisdn(contact.msisdn, im)
             .then(function(update) {
                 var clean = true;  // clean tracks if api call is unnecessary
                 for (i=0;i<update.objects.length;i++) {

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -1633,6 +1633,77 @@ module.exports = function() {
             }
         }
     },
+    // Nursereg subscription for 27821238888
+    {
+        'request': {
+            'method': 'GET',
+            'params': {
+                'to_addr': '+27821238888'
+            },
+            'headers': {
+                'Authorization': ['Basic ' + new Buffer('test:test').toString('base64')],
+                'Content-Type': ['application/json']
+            },
+            'url': 'http://ndoh-control/api/v1/subscription/',
+        },
+        'response': {
+            "code": 200,
+            "meta": {
+                "limit": 20,
+                "next": null,
+                "offset": 0,
+                "previous": null,
+                "total_count": 0
+            },
+            "data": {
+                "objects": []
+            }
+        }
+    },
+    // Nursereg subscription for 27821238889
+    {
+        'request': {
+            'method': 'GET',
+            'params': {
+                'to_addr': '+27821238889'
+            },
+            'headers': {
+                'Authorization': ['Basic ' + new Buffer('test:test').toString('base64')],
+                'Content-Type': ['application/json']
+            },
+            'url': 'http://ndoh-control/api/v1/subscription/',
+        },
+        'response': {
+            "code": 200,
+            "meta": {
+                "limit": 20,
+                "next": null,
+                "offset": 0,
+                "previous": null,
+                "total_count": 0
+            },
+            "data": {
+                "objects": [
+                    {
+                        "active": true,
+                        "completed": false,
+                        "contact_key": "e5b0888cdb4347158ea5cd2f2147d28f",
+                        "created_at": "2014-08-05T11:22:34.838969",
+                        "id": 1,
+                        "lang": "en",
+                        "message_set": "/api/v1/message_set/11/",
+                        "next_sequence_number": 1,
+                        "process_status": 0,
+                        "resource_uri": "/api/v1/subscription/1/",
+                        "schedule": "/api/v1/periodic_task/1/",
+                        "to_addr": "+27821238889",
+                        "updated_at": "2014-08-05T11:22:34.838996",
+                        "user_account": "1aa0dea2f82945a48cc258c61d756f16"
+                    }
+                ]
+            }
+        }
+    },
 
 // POST Snappy Ticket
     // Snappy ticket post - with clinic_code

--- a/test/nurse_ussd.test.js
+++ b/test/nurse_ussd.test.js
@@ -435,6 +435,7 @@ describe("app", function() {
                         state: 'st_end_reg',
                         reply: "Thank you. Weekly NurseConnect messages will now be sent to this number."
                     })
+                    .check.reply.ends_session()
                     .run();
             });
             it("should save extras", function() {
@@ -1153,7 +1154,7 @@ describe("app", function() {
         });
 
         // Change to New Number
-        describe("switch to new number", function() {
+        describe.only("switch to new number", function() {
             describe("choosing to switch to new number", function() {
                 it("should go to st_change_num", function() {
                     return tester
@@ -1292,6 +1293,23 @@ describe("app", function() {
                         .run();
                 });
             });
+            describe("entering non-opted-out number with active subs", function() {
+                it("should block progress", function() {
+                    return tester
+                        .setup.user.addr('27821237777')
+                        .inputs(
+                            {session_event: 'new'}  // dial in
+                            , '2'  // st_subscribed - change num
+                            , '0821238889'  // st_change_num
+                        )
+                        .check.interaction({
+                            state: 'st_block_active_subs',
+                            reply: "Sorry, the number you are trying to move to already has an active registration. To manage that registration, please redial from that number."
+                        })
+                        .check.reply.ends_session()
+                        .run();
+                });
+            });
         });
 
         // Change Details
@@ -1339,6 +1357,7 @@ describe("app", function() {
                             state: 'st_end_detail_changed',
                             reply: "Thank you. Your NurseConnect details have been changed. To change any other details, please dial *120*550*5# again."
                         })
+                        .check.reply.ends_session()
                         .run();
                 });
                 it("should save extras", function() {

--- a/test/nurse_ussd.test.js
+++ b/test/nurse_ussd.test.js
@@ -1174,7 +1174,7 @@ describe("app", function() {
         });
 
         // Change to New Number
-        describe.only("switch to new number", function() {
+        describe("switch to new number", function() {
             describe("choosing to switch to new number", function() {
                 it("should go to st_change_num", function() {
                     return tester


### PR DESCRIPTION
Endstate that says `Sorry, the number you are trying to move to already has an active registration.  To manage that registration, please redial from that number.`
